### PR TITLE
Optimize solver reset(), replaceAll()

### DIFF
--- a/include/ae/SMTUtils.hpp
+++ b/include/ae/SMTUtils.hpp
@@ -77,8 +77,15 @@ namespace ufo
       return conjoin (eqs, efac);
     }
 
-    ExprSet allVars;
-    Expr getModel() { return getModel(allVars); }
+    Expr lastCand;
+    Expr getModel()
+    {
+      if (!can_get_model)
+        return NULL;
+      ExprSet allVars;
+      filter (lastCand, bind::IsConst (), inserter (allVars, allVars.begin()));
+      return getModel(allVars);
+    }
 
     void getModel (ExprSet& vars, ExprMap& e)
     {
@@ -102,13 +109,21 @@ namespace ufo
 
     template <typename T> boost::tribool isSat(T& cnjs, bool reset=true)
     {
-      allVars.clear();
       if (m != NULL) { free(m); m = NULL; }
       if (reset) smt.reset();
-      for (auto & c : cnjs)
+      if (cnjs.size() >= 1)
       {
-        filter (c, bind::IsConst (), inserter (allVars, allVars.begin()));
-        smt.assertExpr(c);
+        for (auto & c : cnjs)
+        {
+          smt.assertExpr(c);
+        }
+        lastCand = conjoin(cnjs);
+      }
+      else
+      {
+        lastCand = NULL;
+        can_get_model = false;
+        return true;
       }
       boost::tribool res = smt.solve ();
       can_get_model = res ? true : false;

--- a/include/deep/RndLearner.hpp
+++ b/include/deep/RndLearner.hpp
@@ -116,28 +116,17 @@ namespace ufo
           SamplFactory& sf1 = sfs[ind1].back();
 
           cand1 = curCandidates[ind1];
-
-          for (auto & v : invarVars[ind1])
-          {
-            cand1 = replaceAll(cand1, v.second, hr.srcVars[v.first]);
-          }
+          cand1 = replaceAll(cand1, invarVarsShort[ind1], hr.srcVars);
           m_smt_solver.assertExpr(cand1);
 
           lmApp = sf1.getAllLemmas();
-          for (auto & v : invarVars[ind1])
-          {
-            lmApp = replaceAll(lmApp, v.second, hr.srcVars[v.first]);
-          }
+          lmApp = replaceAll(lmApp, invarVarsShort[ind1], hr.srcVars);
           m_smt_solver.assertExpr(lmApp);
         }
 
         // pushing dst relation
         cand2 = curCandidates[ind2];
-
-        for (auto & v : invarVars[ind2])
-        {
-          cand2 = replaceAll(cand2, v.second, hr.dstVars[v.first]);
-        }
+        cand2 = replaceAll(cand2, invarVarsShort[ind2], hr.dstVars);
 
         m_smt_solver.assertExpr(mk<NEG>(cand2));
 
@@ -218,10 +207,7 @@ namespace ufo
         auto & hr = ruleManager.chcs[i];
         if (!hr.isInductive) continue;
 
-        for (auto & v : invarVars[0])
-        {
-          allLemmas = replaceAll(allLemmas, v.second, hr.srcVars[v.first]);
-        }
+        allLemmas = replaceAll(allLemmas, invarVarsShort[0], hr.srcVars);
       }
 
       BndExpl bnd(ruleManager, allLemmas, printLog);
@@ -335,10 +321,7 @@ namespace ufo
         Expr invApp = curCandidates[ind];
         if (safety_progress[num-1] == true) continue;
 
-        for (auto & v : invarVars[ind])
-        {
-          invApp = replaceAll(invApp, v.second, hr.srcVars[v.first]);
-        }
+        invApp = replaceAll(invApp, invarVarsShort[ind], hr.srcVars);
 
         m_smt_safety_solvers[num-1].assertExpr(invApp);
         safety_progress[num-1] = bool(!m_smt_safety_solvers[num-1].solve ());
@@ -383,11 +366,7 @@ namespace ufo
                 !hr.isQuery)
             {
               Expr lemma2add = curCandidates[ind];
-
-              for (auto & v : invarVars[ind])
-              {
-                lemma2add = replaceAll(lemma2add, v.second, hr.srcVars[v.first]);
-              }
+              lemma2add = replaceAll(lemma2add, invarVarsShort[ind], hr.srcVars);
 
               numOfSMTChecks++;
               if (u.implies(hr.body, lemma2add)) continue;

--- a/include/deep/RndLearnerV2.hpp
+++ b/include/deep/RndLearnerV2.hpp
@@ -99,10 +99,7 @@ namespace ufo
       SamplFactory& sf = sfs[ind].back();
 
       Expr lmApp = sf.getAllLemmas();
-      for (int i = 0; i < qu->srcVars.size(); i++)
-      {
-        lmApp = replaceAll(lmApp, invarVars[ind][i], qu->srcVars[i]);
-      }
+      lmApp = replaceAll(lmApp, invarVarsShort[ind], qu->srcVars);
       m_smt_solver.assertExpr(lmApp);
 
       numOfSMTChecks++;
@@ -119,11 +116,7 @@ namespace ufo
       for (int i = candSet.size() - 1; i >= 0; i--)
       {
         Expr candPrime = candSet[i];
-
-        for (int j = 0; j < hr->srcVars.size(); j++)
-        {
-          candPrime = replaceAll(candPrime, hr->srcVars[j], hr->dstVars[j]);
-        }
+        candPrime = replaceAll(candPrime, hr->srcVars, hr->dstVars);
 
         m_smt_solver.reset();
         m_smt_solver.assertExpr (hr->body);
@@ -159,11 +152,7 @@ namespace ufo
     bool initCheckCand(HornRuleExt* fc, Expr cand)
     {
       Expr candPrime = cand;
-
-      for (int j = 0; j < fc->dstVars.size(); j++)
-      {
-        candPrime = replaceAll(candPrime, invarVars[0][j], fc->dstVars[j]);
-      }
+      candPrime = replaceAll(candPrime, invarVarsShort[0], fc->dstVars);
 
       m_smt_solver.reset();
       m_smt_solver.assertExpr (fc->body);

--- a/include/deep/RndLearnerV3.hpp
+++ b/include/deep/RndLearnerV3.hpp
@@ -139,8 +139,7 @@ namespace ufo
 
     Expr renameCand(Expr newCand, ExprVector& varsRenameFrom, int invNum)
     {
-      for (auto & v : invarVars[invNum])
-        newCand = replaceAll(newCand, varsRenameFrom[v.first], v.second);
+      newCand = replaceAll(newCand, varsRenameFrom, invarVarsShort[invNum]);
       return newCand;
     }
 
@@ -1059,8 +1058,7 @@ namespace ufo
           for (auto & cand : candidates[invNum])
           {
             Expr repl = cand;
-            for (auto & v : invarVars[invNum])
-              repl = replaceAll(repl, v.second, hr->dstVars[v.first]);
+            repl = replaceAll(repl, invarVarsShort[invNum], hr->dstVars);
             vals[cand] = u.eval(repl);
           }
 
@@ -1693,7 +1691,7 @@ namespace ufo
         for (auto & a : annotations[srcNum]) lms.insert(a);
         for (auto a : lms)
         {
-          for (auto & v : invarVars[srcNum]) a = replaceAll(a, v.second, hr.srcVars[v.first]);
+          a = replaceAll(a, invarVarsShort[srcNum], hr.srcVars);
           exprs.insert(a);
         }
       }
@@ -1705,7 +1703,7 @@ namespace ufo
         for (auto & a : annotations[dstNum]) lms.insert(a);
         for (auto a : lms)
         {
-          for (auto & v : invarVars[dstNum]) a = replaceAll(a, v.second, hr.dstVars[v.first]);
+          a = replaceAll(a, invarVarsShort[dstNum], hr.dstVars);
           negged.insert(mkNeg(a));
         }
         exprs.insert(disjoin(negged, m_efac));

--- a/include/ufo/Smt/Z3n.hpp
+++ b/include/ufo/Smt/Z3n.hpp
@@ -523,22 +523,31 @@ namespace ufo
     z3::context &ctx;
     z3::solver solver;
     ExprFactory &efac;
+    int depth = 1;
 
   public:
     typedef ZSolver<Z> this_type;
     typedef ZModel<Z> Model;
 
     ZSolver (Z &z) :
-      z3(z), ctx (z.get_ctx ()), solver (z.get_ctx ()), efac (z.get_efac ()) {}
+      z3(z), ctx (z.get_ctx ()), solver (z.get_ctx ()), efac (z.get_efac ())
+    {
+      solver.push ();
+    }
 
     ZSolver (Z &z, const char *logic) :
-      z3(z), ctx (z.get_ctx ()), solver (z.get_ctx (), logic), efac (z.get_efac ()) {}
+      z3(z), ctx (z.get_ctx ()), solver (z.get_ctx (), logic), efac (z.get_efac ())
+    {
+      solver.push ();
+    }
 
     ZSolver (Z &z, unsigned to) :
-    z3(z), ctx (z.get_ctx ()), solver (z.get_ctx ()), efac (z.get_efac ()) {
+    z3(z), ctx (z.get_ctx ()), solver (z.get_ctx ()), efac (z.get_efac ())
+    {
+      solver.push ();
       ZParams<Z> p(z);
-      p.set("timeout", to);
-      solver.set(p);
+      p.set ("timeout", to);
+      solver.set (p);
     }
 
     Z& getContext () {return z3;}
@@ -664,9 +673,10 @@ namespace ufo
       return new ZModel<Z> (z3, m);
     }
 
-    void push () { solver.push (); }
-    void pop (unsigned n = 1) { solver.pop (n); }
-    void reset () { solver.reset (); }
+    void push () { depth++; solver.push (); }
+    void pop (unsigned n = 1) { depth -= n; solver.pop (n); }
+    //void reset () { solver.reset (); }
+    void reset () { solver.pop (depth); solver.push (); depth = 1; }
   };
 
 


### PR DESCRIPTION
For whatever reason, ZSolver::reset() is a very costly operation; this
may be due to some bug in Z3. In the meantime, however, an alternative
implementation using ZSolver::push() and pop() has been provided.

Additionally, several places in all versions of RndLearner were calling
replaceAll() in a loop (for each variable) instead of using the vector
version.

Finally, SMTUtils::isSat() was performing an expensive filter()
operation on every invocation; this has been moved into the location
it's actually needed, getModel().

All of these changes taken together result in a nearly order of
magnitude speed up on my machine.