### PR TITLE
Fix BndExpl For Nested Array Operations

### DIFF
--- a/include/deep/BndExpl.hpp
+++ b/include/deep/BndExpl.hpp
@@ -608,8 +608,11 @@ namespace ufo
               if (debug) outs () << *bvar << " = " << *m << ", ";
               if (j == 0)
               {
-                if (isOpX<SELECT>(bvar))
-                  concrInvs[srcRel].insert(mk<EQ>(vars[i]->left(), allModels[bvar->left()]));
+                Expr arr = bvar;
+                while (isOpX<SELECT>(arr) || isOpX<STORE>(arr))
+                  arr = arr->left();
+                if (arr != bvar)
+                  concrInvs[srcRel].insert(mk<EQ>(vars[i]->left(), allModels[arr]));
                 else
                   concrInvs[srcRel].insert(mk<EQ>(vars[i], m));
               }

--- a/include/deep/RndLearnerV3.hpp
+++ b/include/deep/RndLearnerV3.hpp
@@ -834,12 +834,12 @@ namespace ufo
         int sz = cands[rel].size();
 //          getArrInds(ssas[invNum], se);
         if (isOpX<FORALL>(cnd))
-          qfInvs.insert(cnd->right()->right());              // only the actual inv without the phaseGuard/mbp
+          qfInvs.insert(cnd->last()->right());              // only the actual inv without the phaseGuard/mbp
         else
           candsToDat.insert(candImpl);
         for (auto & inv : sfs[invNum].back().learnedExprs)   // basically, invs
           if (isOpX<FORALL>(inv))
-            qfInvs.insert(inv->right()->right());
+            qfInvs.insert(inv->last()->right());
           else
             candsToDat.insert(inv);
 //          for (auto & s : se)


### PR DESCRIPTION
Some benchmarks include nested array operations, e.g.
(store (store ...) j (select ...), which leads to models with the
reverse nesting, e.g. (select (store ...) j); some code in BndExpl
wasn't detecting this properly, leading to a Segmentation Fault as
it blindly assumed the array variable was in the first position.
This has been fixed.

Also, V3 was assuming the second argument of a quantifier was the body;
this has also been fixed (reproduce by only including the change to BndExpl
on the below benchmark).

To reproduce:
    freqhorn --v3 --disj --all-mbp --stren-mbp \
        bench_horn_multiple/array_bubble_sort.smt2