### PR TITLE
Fix SeedMiner Out Of Bounds Array Read

### DIFF
--- a/include/sampl/SeedMiner.hpp
+++ b/include/sampl/SeedMiner.hpp
@@ -372,7 +372,9 @@ namespace ufo
         retrieveDeltas(e, hr.srcVars, hr.dstVars, deltas);
         for (auto & a : deltas) obtainSeeds(a);
         ExprVector vars2elim;
-        for (int i = 0; i < hr.srcVars.size(); i++)
+        int varslimit = hr.srcVars.size() < hr.dstVars.size() ?
+                        hr.srcVars.size() : hr.dstVars.size();
+        for (int i = 0; i < varslimit; i++)
           if (containsOp<ARRAY_TY>(hr.srcVars[i]))
             vars2elim.push_back(hr.srcVars[i]);
           else


### PR DESCRIPTION
Code in SeedMiner was assuming that hr.srcVars.size() ==
hr.dstVars.size(), meaning an out-of-bounds read if the two lengths
weren't the same (as is often the case for non-transition-system CHCs).
This resulted in a Z3 failed assertion as a sort AST node (INT) appeared
in later stages of the code. This has been fixed.

To reproduce:
    freqhorn --v1 bench_horn_multiple/samples_multiple_inv_06.smt2