### PR TITLE
Optimize solver reset(), isSat() (#26)

### DIFF
--- a/include/ufo/Smt/Z3n.hpp
+++ b/include/ufo/Smt/Z3n.hpp
@@ -530,19 +530,28 @@ namespace ufo
     z3::context &ctx;
     z3::solver solver;
     ExprFactory &efac;
+    int depth = 1;
 
   public:
     typedef ZSolver<Z> this_type;
     typedef ZModel<Z> Model;
 
     ZSolver (Z &z) :
-      z3(z), ctx (z.get_ctx ()), solver (z.get_ctx ()), efac (z.get_efac ()) {}
+      z3(z), ctx (z.get_ctx ()), solver (z.get_ctx ()), efac (z.get_efac ())
+    {
+      solver.push ();
+    }
 
     ZSolver (Z &z, const char *logic) :
-      z3(z), ctx (z.get_ctx ()), solver (z.get_ctx (), logic), efac (z.get_efac ()) {}
+      z3(z), ctx (z.get_ctx ()), solver (z.get_ctx (), logic), efac (z.get_efac ())
+    {
+      solver.push ();
+    }
 
     ZSolver (Z &z, unsigned to) :
-    z3(z), ctx (z.get_ctx ()), solver (z.get_ctx ()), efac (z.get_efac ()) {
+    z3(z), ctx (z.get_ctx ()), solver (z.get_ctx ()), efac (z.get_efac ())
+    {
+      solver.push ();
       ZParams<Z> p(z);
       p.set("timeout", to);
 //      p.set("arith.solver", (unsigned)2);
@@ -672,9 +681,10 @@ namespace ufo
       return new ZModel<Z> (z3, m);
     }
 
-    void push () { solver.push (); }
-    void pop (unsigned n = 1) { solver.pop (n); }
-    void reset () { solver.reset (); }
+    void push () { depth++; solver.push (); }
+    void pop (unsigned n = 1) { depth -= n; solver.pop (n); }
+    //void reset () { solver.reset (); }
+    void reset () { solver.pop (depth); solver.push (); depth = 1; }
   };
 
 


### PR DESCRIPTION
Port of #26 from 'rnd' branch.
* Optimize solver reset()

For whatever reason, ZSolver::reset() is a very costly operation; this
may be due to some bug in Z3. In the meantime, however, an alternative
implementation using ZSolver::push() and pop() has been provided.
The semantics are unchanged, but execution is considerably faster.

* Optimize isSat()

SMTUtils::isSat() was performing an expensive filter()
operation on every invocation; this has been moved into the location
it's actually needed, getModel().