### PR TITLE
Z3 distinct, More error checking, --debug in help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 /llvm-seahorn/
 /seahorn-llvm/
 /gtags.files
+
+*.swp

--- a/include/ae/AeValSolver.hpp
+++ b/include/ae/AeValSolver.hpp
@@ -18,10 +18,10 @@ namespace ufo
     Expr s;
     Expr t;
     ExprSet v; // existentially quantified vars
-    ExprSet sVars;
-    ExprSet stVars;
+    ExprSet sVars; // all vars (stVars U v)
+    ExprSet stVars; // universally quantified vars
 
-    ExprMap modelInvalid;
+    ExprMap modelInvalid; // key: variable | value: assignment in model
     ExprMap separateSkols;
 
     ExprFactory &efac;
@@ -37,7 +37,7 @@ namespace ufo
     ExprSet sensitiveVars; // for compaction
     set<int> bestIndexes; // for compaction
     map<Expr, ExprVector> skolemConstraints;
-    bool skol;
+    bool skol; // whether or not to produce a skolem (function)
     int debug;
     unsigned fresh_var_ind;
 
@@ -1211,6 +1211,12 @@ namespace ufo
     if(debug >= 3) {
       outs() << "s part: " << s << "\n";
       outs() << "t part: " << t << "\n";
+      outs() << "s vars: [ ";
+      for (auto &v : fa_qvars) outs() << v << " ";
+      outs() << "]\n";
+      outs() << "t vars: [ ";
+      for (auto &v : ex_qvars) outs() << v << " ";
+      outs() << "]\n";
     }
 
     Expr t_orig = t;

--- a/include/ufo/Smt/Z3n.hpp
+++ b/include/ufo/Smt/Z3n.hpp
@@ -174,12 +174,14 @@ namespace ufo
     z3::context &ctx = z3.get_ctx ();
 
     Z3_ast_vector b = Z3_parse_smtlib2_string (ctx, smt.c_str (), 0, NULL, NULL, 0, NULL, NULL);
+    ctx.check_error ();
     Z3_ast* args = new Z3_ast[Z3_ast_vector_size(ctx, b)];
 
     for (unsigned i = 0; i < Z3_ast_vector_size(ctx, b); ++i) {
       args[i] = Z3_ast_vector_get(ctx, b, i);
     }
 
+    ctx.check_error ();
     z3::ast ast (ctx, Z3_mk_and(ctx, Z3_ast_vector_size(ctx, b), args));
     ctx.check_error ();
     return z3.toExpr (ast);
@@ -191,12 +193,17 @@ namespace ufo
     z3::context &ctx = z3.get_ctx ();
 
     Z3_ast_vector b = Z3_parse_smtlib2_file (ctx, fname, 0, NULL, NULL, 0, NULL, NULL);
-    Z3_ast* args = new Z3_ast[Z3_ast_vector_size(ctx, b)];
+    ctx.check_error ();
+    unsigned astsize = Z3_ast_vector_size(ctx, b);
+    if (astsize == 0)
+      return NULL;
+    Z3_ast* args = new Z3_ast[astsize];
 
-    for (unsigned i = 0; i < Z3_ast_vector_size(ctx, b); ++i) {
+    for (unsigned i = 0; i < astsize; ++i) {
       args[i] = Z3_ast_vector_get(ctx, b, i);
     }
     z3:: ast ast(ctx);
+    ctx.check_error ();
     if(Z3_ast_vector_size(ctx, b) > 1){
       z3::ast ast1 (ctx, Z3_mk_and(ctx, Z3_ast_vector_size(ctx, b), args));
       ast = ast1;

--- a/include/ufo/Smt/ZExprConverter.hpp
+++ b/include/ufo/Smt/ZExprConverter.hpp
@@ -518,7 +518,6 @@ namespace ufo
       if (bVal == Z3_L_TRUE) return mk<TRUE> (efac);
       if (bVal == Z3_L_FALSE) return mk<FALSE> (efac);
 
-
       Z3_ast_kind kind = z.kind ();
 
 
@@ -794,6 +793,9 @@ namespace ufo
 	  break;
         case Z3_OP_REM:
           e = mknary<REM> (args.begin (), args.end ());
+          break;
+        case Z3_OP_DISTINCT:
+          e = mknary<NEQ> (args.begin(), args.end());
           break;
         case Z3_OP_CONST_ARRAY:
           {

--- a/tools/aeval/Ae.cpp
+++ b/tools/aeval/Ae.cpp
@@ -69,6 +69,7 @@ void printUsage()
   outs() << "    --opt              optimize quantifier elimination\n";
   outs() << "    --merge            combina Skolem functions into a single ite-formula\n";
   outs() << "    --compact          attempt to make Skolems more compact\n";
+  outs() << "    --debug <lvl>      enable debug logging (higher = more)\n";
 }
 
 int main (int argc, char ** argv)


### PR DESCRIPTION
ZExprConverter didn't support 'distinct', fixed (from commit
56ee16d3ee89d2b265e0d9d6679026e5a9daab6a in 'rnd' branch).

Z3n wasn't checking errors enough, so would just segfault on failed
parse; now it throws exceptions like it should. Also, would segfault if
Z3 didn't parse anything; now returns NULL.

Help message didn't include --debug option; now it does.

Finally, some more debug output for tool.