### PR TITLE
Add support for SyGuS files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,8 @@ else()
   set(GMPXX_LIB "")
 endif()
 
+find_package(BISON 3.2 REQUIRED)
+
 install(DIRECTORY include/
   DESTINATION include
   FILES_MATCHING
@@ -157,13 +159,13 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   add_definitions( -Wno-unused-local-typedefs)
 endif ()
 
-# add the include directory from the build tree
-include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/include)
-
 ### add our include directories to the front, overriding directories
 ### specified by external packages.
 include_directories(BEFORE
-  ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${CMAKE_CURRENT_BINARY_DIR}/include)
+  ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# add the include directory from the build tree
+include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/include)
+
+add_subdirectory(include)
 add_subdirectory(tools)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,2 +1,1 @@
-add_subdirectory(aeval)
 add_subdirectory(sygus)

--- a/include/ae/AeValSolver.hpp
+++ b/include/ae/AeValSolver.hpp
@@ -270,20 +270,20 @@ namespace ufo
     /**
      * Model of S /\ \neg T (if AE-formula is invalid)
      */
-    void printModelNeg()
+    void printModelNeg(ostream& out)
     {
-      outs () << "(model\n";
+      out << "(model\n";
       Expr witn = mk<IMPL>(s, t);
       for (auto &var : sVars){
         Expr assnmt = var == modelInvalid[var] ? getDefaultAssignment(var) : modelInvalid[var];
         if (debug)
           witn = replaceAll(witn, var, assnmt);
 
-        outs () << "  (define-fun " << *var << " () " <<
+        out << "  (define-fun " << *var << " () " <<
           (bind::isBoolConst(var) ? "Bool" : (bind::isIntConst(var) ? "Int" : "Real"))
                 << "\n    " << *assnmt << ")\n";
       }
-      outs () << ")\n";
+      out << ")\n";
 
       if (debug){
         outs () << "Sanity check [model]: " << (bool)u.isFalse(witn) << "\n";
@@ -1234,7 +1234,7 @@ namespace ufo
 
     if (ae.solve()){
       outs () << "Iter: " << ae.getPartitioningSize() << "; Result: invalid\n";
-      ae.printModelNeg();
+      ae.printModelNeg(outs());
       outs() << "\nvalid subset:\n";
       u.serialize_formula(simplifyBool(simplifyArithm(ae.getValidSubset(compact))));
     } else {

--- a/include/ae/CLIParsing.hpp
+++ b/include/ae/CLIParsing.hpp
@@ -40,3 +40,18 @@ char * getSmtFileName(int num, int argc, char ** argv)
   }
   return NULL;
 }
+
+char * getSyGuSFileName(int num, int argc, char ** argv)
+{
+  int num1 = 1;
+  for (int i = 1; i < argc; i++)
+  {
+    int len = strlen(argv[i]);
+    if (len >= 5 && strcmp(argv[i] + len - 3, ".sl") == 0)
+    {
+      if (num1 == num) return argv[i];
+      else num1++;
+    }
+  }
+  return NULL;
+}

--- a/include/ae/CLIParsing.hpp
+++ b/include/ae/CLIParsing.hpp
@@ -1,0 +1,42 @@
+
+#include <cstdlib>
+#include <cstring>
+
+bool getBoolValue(const char * opt, bool defValue, int argc, char ** argv)
+{
+  for (int i = 1; i < argc; i++)
+  {
+    if (strcmp(argv[i], opt) == 0) return true;
+  }
+  return defValue;
+}
+
+int getIntValue(const char * opt, int defValue, int argc, char ** argv)
+{
+  for (int i = 1; i < argc-1; i++)
+  {
+    if (strcmp(argv[i], opt) == 0)
+    {
+      char* p;
+      int num = strtol(argv[i+1], &p, 10);
+      if (*p) return 1;      // if used w/o arg, return boolean
+      else return num;
+    }
+  }
+  return defValue;
+}
+
+char * getSmtFileName(int num, int argc, char ** argv)
+{
+  int num1 = 1;
+  for (int i = 1; i < argc; i++)
+  {
+    int len = strlen(argv[i]);
+    if (len >= 5 && strcmp(argv[i] + len - 5, ".smt2") == 0)
+    {
+      if (num1 == num) return argv[i];
+      else num1++;
+    }
+  }
+  return NULL;
+}

--- a/include/ae/SMTUtils.hpp
+++ b/include/ae/SMTUtils.hpp
@@ -619,82 +619,82 @@ namespace ufo
       return conjoin(cnjs, efac);
     }
 
-    void print (Expr e)
+    void print (Expr e, ostream& os = std::cout)
     {
       if (isOpX<FORALL>(e) || isOpX<EXISTS>(e))
       {
         if (isOpX<FORALL>(e)) outs () << "(forall (";
-        else outs () << "(exists (";
+        else os << "(exists (";
 
         for (int i = 0; i < e->arity() - 1; i++)
         {
           Expr var = bind::fapp(e->arg(i));
-          outs () << "(" << *var << " " << varType(var) << ")";
-          if (i != e->arity() - 2) outs () << " ";
+          os << "(" << *var << " " << varType(var) << ")";
+          if (i != e->arity() - 2) os << " ";
         }
-        outs () << ") ";
-        print (e->last());
-        outs () << ")";
+        os << ") ";
+        print (e->last(), os);
+        os << ")";
       }
       else if (isOpX<NEG>(e))
       {
-        outs () << "(not ";
-        print(e->left());
-        outs () << ")";
+        os << "(not ";
+        print(e->left(), os);
+        os << ")";
       }
       else if (isOpX<AND>(e))
       {
-        outs () << "(and ";
+        os << "(and ";
         ExprSet cnjs;
         getConj(e, cnjs);
         int i = 0;
         for (auto & c : cnjs)
         {
           i++;
-          print(c);
-          if (i != cnjs.size()) outs () << " ";
+          print(c, os);
+          if (i != cnjs.size()) os << " ";
         }
-        outs () << ")";
+        os << ")";
       }
       else if (isOpX<OR>(e))
       {
-        outs () << "(or ";
+        os << "(or ";
         ExprSet dsjs;
         getDisj(e, dsjs);
         int i = 0;
         for (auto & d : dsjs)
         {
           i++;
-          print(d);
-          if (i != dsjs.size()) outs () << " ";
+          print(d, os);
+          if (i != dsjs.size()) os << " ";
         }
-        outs () << ")";
+        os << ")";
       }
       else if (isOpX<IMPL>(e) || isOp<ComparissonOp>(e))
       {
-        if (isOpX<IMPL>(e)) outs () << "(=> ";
-        if (isOpX<EQ>(e)) outs () << "(= ";
-        if (isOpX<GEQ>(e)) outs () << "(>= ";
-        if (isOpX<LEQ>(e)) outs () << "(<= ";
-        if (isOpX<LT>(e)) outs () << "(< ";
-        if (isOpX<GT>(e)) outs () << "(> ";
-        if (isOpX<NEQ>(e)) outs () << "(distinct ";
-        print(e->left());
-        outs () << " ";
-        print(e->right());
-        outs () << ")";
+        if (isOpX<IMPL>(e)) os << "(=> ";
+        if (isOpX<EQ>(e)) os << "(= ";
+        if (isOpX<GEQ>(e)) os << "(>= ";
+        if (isOpX<LEQ>(e)) os << "(<= ";
+        if (isOpX<LT>(e)) os << "(< ";
+        if (isOpX<GT>(e)) os << "(> ";
+        if (isOpX<NEQ>(e)) os << "(distinct ";
+        print(e->left(), os);
+        os << " ";
+        print(e->right(), os);
+        os << ")";
       }
       else if (isOpX<ITE>(e))
       {
-        outs () << "(ite ";
-        print(e->left());
-        outs () << " ";
-        print(e->right());
-        outs () << " ";
-        print(e->last());
-        outs () << ")";
+        os << "(ite ";
+        print(e->left(), os);
+        os << " ";
+        print(e->right(), os);
+        os << " ";
+        print(e->last(), os);
+        os << ")";
       }
-      else outs () << z3.toSmtLib (e);
+      else os << z3.toSmtLib (e);
     }
 
     void serialize_formula(Expr form)

--- a/include/sygus/CMakeLists.txt
+++ b/include/sygus/CMakeLists.txt
@@ -1,0 +1,8 @@
+#if (BISON_FOUND)
+  message(STATUS "Using Bison to generate SyGuS parser")
+  BISON_TARGET(SyGuSParser SyGuSParser.yy ${CMAKE_CURRENT_BINARY_DIR}/SyGuSParser.bison.cpp)
+  if (NOT ${BISON_SyGuSParser_DEFINED})
+    message(FATAL_ERROR "Bison found but macro failed!")
+  endif()
+  add_custom_target(SyGuSParserBison DEPENDS ${BISON_SyGuSParser_OUTPUT_SOURCE})
+#endif()

--- a/include/sygus/SyGuSParser.yy
+++ b/include/sygus/SyGuSParser.yy
@@ -50,13 +50,15 @@ FILE *infile;
 yy::parser::symbol_type yylex()
 {
   bool isComment = false;
-  char c;
+  char c, nextc;
   std::string s;
 
   loc.step();
 
   c = fgetc(infile);
   loc.columns();
+  nextc = fgetc(infile);
+  ungetc(nextc, infile);
 
   switch (c)
   {
@@ -72,6 +74,8 @@ yy::parser::symbol_type yylex()
     case ')':
       return yy::parser::make_RPAR(')', loc);
     case '_':
+      if (nextc != ' ' && nextc != '\t' && nextc != '\n')
+        break; // Only recognize an independent _ as USCORE
       return yy::parser::make_USCORE('_', loc);
     case ';':
       isComment = true;

--- a/include/sygus/SyGuSParser.yy
+++ b/include/sygus/SyGuSParser.yy
@@ -1,0 +1,332 @@
+
+%require "3.2"
+%language "c++"
+%define api.value.type variant
+%define api.token.constructor
+%define parse.trace
+%define parse.error verbose
+%locations
+
+%code requires {
+  #include "ufo/Expr.hpp"
+  #include "ufo/Smt/EZ3.hh"
+  #include "sygus/SynthProblem.hpp"
+}
+
+%parse-param {ufo::SynthProblem& prob} {ufo::ExprFactory& efac} {ufo::EZ3& z3}
+
+%token <char> LPAR
+%token <char> RPAR
+%token <char> USCORE /* Underscore */
+%token <std::string> MATCHEDPAR
+%token <std::string> ID
+%token <std::string> ARRAY
+%token <std::string> BITVEC
+%token <std::string> COMMENT
+%token <std::string> SETLOGIC
+%token <std::string> SYNTHFUN
+%token <std::string> SYNTHINV
+%token <std::string> DEFFUN
+%token <std::string> DECLVAR
+%token <std::string> DECLPVAR
+%token <std::string> CONSTRAINT
+%token <std::string> INVCONSTRAINT
+%token <std::string> CHECKSYNTH
+%token YYEOF 0
+
+/* %printer { yyo << $$; } <*> */
+
+%{
+%}
+
+%code {
+namespace yy
+{
+std::string toparse; /* Everything we'll eventually send to Z3 parser */
+std::unordered_set<std::string> funcs; /* Defined functions */
+
+yy::location loc;
+FILE *infile;
+yy::parser::symbol_type yylex()
+{
+  bool isComment = false;
+  char c;
+  std::string s;
+
+  loc.step();
+
+  c = fgetc(infile);
+  loc.columns();
+
+  switch (c)
+  {
+    case EOF:
+      return yy::parser::make_YYEOF(loc);
+    case '\n':
+      loc.lines();
+    case ' ':
+    case '\t':
+      return yylex();
+    case '(':
+      return yy::parser::make_LPAR('(', loc);
+    case ')':
+      return yy::parser::make_RPAR(')', loc);
+    case '_':
+      return yy::parser::make_USCORE('_', loc);
+    case ';':
+      isComment = true;
+      break;
+  }
+
+  while (c != ' ' && c != '\n' && c != '\t' && c != ')' && c != '(')
+  {
+    s += c;
+    c = fgetc(infile);
+  }
+  ungetc(c, infile);
+  loc.columns(s.length() - 1);
+
+  if (isComment)
+    return yy::parser::make_COMMENT(s, loc);
+
+  if (s == "Array")
+    return yy::parser::make_ARRAY(s, loc);
+  if (s == "BitVec")
+    return yy::parser::make_BITVEC(s, loc);
+  if (s == "constraint")
+    return yy::parser::make_CONSTRAINT(s, loc);
+  if (s == "inv-constraint")
+    return yy::parser::make_INVCONSTRAINT(s, loc);
+  if (s == "check-synth")
+    return yy::parser::make_CHECKSYNTH(s, loc);
+  if (s == "declare-var")
+    return yy::parser::make_DECLVAR(s, loc);
+  if (s == "declare-primed-var")
+    return yy::parser::make_DECLPVAR(s, loc);
+  if (s == "define-fun")
+    return yy::parser::make_DEFFUN(s, loc);
+  if (s == "set-logic")
+    return yy::parser::make_SETLOGIC(s, loc);
+  if (s == "synth-fun")
+    return yy::parser::make_SYNTHFUN(s, loc);
+  if (s == "synth-inv")
+    return yy::parser::make_SYNTHINV(s, loc);
+
+  return yy::parser::make_ID(s, loc);
+}
+
+void parser::error(const yy::location &loc, const std::string &s)
+{
+  std::cerr << s << ": " << loc << std::endl;
+}
+}
+}
+
+%%
+
+%start sygusfile;
+
+%nterm <std::vector<std::string>> ids;
+ids:
+    ID ids { std::swap($$, $2); $$.insert($$.begin(), $1); }
+    | matchedpar ids { std::swap($$, $2); $$.insert($$.begin(), $1); }
+    | USCORE ids { std::swap($$, $2); $$.insert($$.begin(), "_"); }
+    | BITVEC ids { std::swap($$, $2); $$.insert($$.begin(), $1); }
+    | {}
+    ;
+
+%nterm <std::string> matchedpar;
+matchedpar:
+           LPAR ids RPAR
+             {
+                if ($2.size() == 1 && yy::funcs.count($2[0]) != 0)
+                  /* For some reason, SyGuS uses `(func)` to call a 0-arity
+                     function. SMT-LIBv2 uses `func`, so save it that way. */
+                  $$ = $2[0];
+                else
+                {
+                  $$ = "(";
+                  for (int i = 0; i < $2.size(); ++i)
+                  {
+                    if (i != 0) $$ += " ";
+                    $$ += $2[i];
+                  }
+                  $$ += ")";
+                }
+             }
+           ;
+
+%nterm <expr::Expr> sort;
+sort:
+       ID
+         {
+            if ($1 == "Bool")
+              $$ = expr::op::sort::boolTy(efac);
+            else if ($1 == "Int")
+              $$ = expr::op::sort::intTy(efac);
+            else if ($1 == "Real")
+              $$ = expr::op::sort::realTy(efac);
+            else if ($1 == "String")
+              assert(0 && "Strings currently unsupported");
+            else
+              $$ = expr::mk<expr::op::UNINT_TY>(efac);
+         }
+       | LPAR ARRAY sort sort RPAR { $$ = expr::op::sort::arrayTy($3, $4); }
+       | LPAR USCORE BITVEC ID RPAR { $$ = ufo::op::bv::bvsort(atoi($4.c_str()), efac); }
+       ;
+
+%nterm <std::vector<expr::Expr>> vardecls;
+vardecls:
+         LPAR ID sort RPAR vardecls
+           {
+              std::swap($$, $5);
+              $$.insert($$.begin(), expr::bind::constDecl(
+                ufo::mkTerm<std::string>($2, efac), $3));
+           }
+         | {}
+         ;
+
+/* Will be parsed by Expr/Z3's parser */
+%nterm <std::string> expr;
+expr:
+     matchedpar
+     | ID
+     ;
+
+/*For newest version (2.1), but won't work for older versions b/c SR-conflict*/
+gramnts:
+        LPAR vardecls RPAR
+        ;
+
+eithers:
+        expr eithers
+        | expr
+        ;
+
+gramprod:
+         LPAR ID sort LPAR eithers RPAR RPAR
+
+gramprods:
+          gramprod gramprods
+          | gramprod
+          ;
+
+grammar:
+        gramnts LPAR gramprods RPAR
+        |
+        ;
+
+/*
+%nterm <std::string> synthdef;
+synthdef:
+         SYNTHFUN
+         | SYNTHINV
+         ;
+*/
+
+%nterm <std::string> topvardecl;
+topvardecl:
+        DECLVAR
+        | DECLPVAR
+        ;
+
+topcommand:
+           COMMENT
+           | LPAR SETLOGIC ID RPAR { prob.logic = $2; }
+           | LPAR SYNTHFUN ID LPAR vardecls RPAR sort grammar RPAR
+               {
+                  $5.push_back($7);
+                  /* TODO: Ignoring grammar for now */
+                  prob.synthfuncs.push_back(ufo::SynthFunc(
+                    ufo::SynthFuncType::SYNTH,
+                    expr::bind::fdecl(expr::mkTerm<std::string>($3, efac), $5)));
+                  /* Z3 needs to know the function exists */
+                  toparse += "\n(declare-fun " + $3 + " (";
+                  for (int i = 0; i < $5.size() - 1; ++i)
+                  {
+                    expr::Expr v = $5[i];
+                    if (i != 0) toparse += " ";
+                    toparse += z3.toSmtLib(v->right());
+                  }
+                  toparse += ") " + z3.toSmtLib($7) + ")";
+                  yy::funcs.insert($3);
+               }
+           | LPAR SYNTHINV ID LPAR vardecls RPAR grammar RPAR
+               {
+                  $5.push_back(expr::op::sort::boolTy(efac));
+                  /* TODO: Ignoring grammar for now */
+                  prob.synthfuncs.push_back(ufo::SynthFunc(
+                    ufo::SynthFuncType::INV,
+                    expr::bind::fdecl(expr::mkTerm<std::string>($3, efac), $5)));
+                  /* Z3 needs to know the function exists */
+                  toparse += "\n(declare-fun " + $3 + " (";
+                  for (int i = 0; i < $5.size() - 1; ++i)
+                  {
+                    expr::Expr v = $5[i];
+                    if (i != 0) toparse += " ";
+                    toparse += z3.toSmtLib(v->right());
+                  }
+                  toparse += ") Bool)";
+                  yy::funcs.insert($3);
+               }
+           | LPAR DEFFUN ID LPAR vardecls RPAR sort expr RPAR
+               {
+                  toparse += "\n(define-fun " + $3 + " (";
+                  for (int i = 0; i < $5.size(); ++i)
+                  {
+                    expr::Expr v = $5[i];
+                    if (i != 0) toparse += " ";
+                    toparse += "(" + expr::getTerm<std::string>(v->left()) + " " + z3.toSmtLib(v->right()) + ")";
+                  }
+                  toparse += ") " + z3.toSmtLib($7) + "\n  " + $8 + "\n)";
+                  yy::funcs.insert($3);
+               }
+           | LPAR topvardecl ID sort RPAR
+               {
+                  std::string sort = z3.toSmtLib($4);
+                  toparse += "\n(declare-fun " + $3 + " () " + sort + ")";
+                  if ($2 == "declare-primed-var")
+                    toparse += "\n(declare-fun " + $3 + "! () " + sort + ")";
+               }
+           | LPAR CONSTRAINT expr RPAR
+               {
+                  toparse += "\n(assert " + $3 + ")";
+               }
+           | LPAR INVCONSTRAINT ID ID ID ID RPAR { assert(0 && "inv-constraint currently unsupported"); }
+           | LPAR CHECKSYNTH RPAR
+               {
+                  toparse += "\n(assert true)";
+                  toparse += "\n(check-sat)";
+                  expr::Expr e;
+                  try
+                  {
+                    e = z3_from_smtlib(z3, toparse);
+                  }
+                  catch (...)
+                  {
+                    std::cout << "To be parsed: \n" << toparse << std::endl;
+                    throw;
+                  }
+                  if (!e)
+                  {
+                    fprintf(stderr, "Expr from Z3 is NULL!\n");
+                    throw 0;
+                  }
+                  assert(ufo::isOpX<expr::op::AND>(e));
+                  prob.constraints.reserve(e->arity() - 1);
+                  for (int i = 0; i < e->arity() - 1; ++i)
+                    prob.constraints.push_back(e->arg(i));
+                  return 0;
+               }
+           ;
+
+topcommands:
+            topcommand
+            | topcommand topcommands
+            ;
+
+sygusfile:
+          topcommands
+          ;
+
+%%

--- a/include/sygus/SyGuSSolver.hpp
+++ b/include/sygus/SyGuSSolver.hpp
@@ -3,6 +3,7 @@
 
 #include "ae/AeValSolver.hpp"
 #include <boost/logic/tribool.hpp>
+#include <fstream>
 
 namespace ufo
 {
@@ -18,14 +19,157 @@ class SyGuSSolver
   SMTUtils u;
   int debug;
 
+  unordered_map<Expr, const SynthFunc*> declToFunc; // K: FDECL, V: SynthFunc
+
   string _errmsg; // Non-empty if Solve() returned false
   unordered_map<const SynthFunc*,Expr> _foundfuncs; // K: func, V: Def
+  vector<const SynthFunc*> _foundfuncsorder; // see findOrdering()
 
   public:
   const string& errmsg = _errmsg;
   const unordered_map<const SynthFunc*,Expr>& foundfuncs = _foundfuncs;
+  const vector<const SynthFunc*>& foundfuncsorder = _foundfuncsorder;
 
   private:
+
+  // Find ordering of foundfuncs, such that
+  // j > i implies that ret[i] doesn't depend on ret[j]
+  void findOrdering()
+  {
+    if (foundfuncsorder.size() == prob.synthfuncs.size())
+      return;
+    assert(foundfuncs.size() == prob.synthfuncs.size());
+
+    _foundfuncsorder.reserve(foundfuncs.size());
+    unordered_set<Expr> found; // K: SynthFunc.decl
+    while (foundfuncsorder.size() != foundfuncs.size())
+    {
+      for (const auto &kv : foundfuncs)
+      {
+        if (found.count(kv.first->decl) != 0)
+          continue;
+        vector<Expr> fapps;
+        filter(kv.second, [] (Expr e) { return isOpX<FAPP>(e); },
+          inserter(fapps, fapps.begin()));
+        bool dobreak = false;
+        for (const Expr &f : fapps)
+          if (declToFunc.count(f->left()) != 0 && found.count(f->left()) == 0)
+          {
+            dobreak = true;
+            break; // We haven't included this fapp's dependencies yet
+          }
+        if (dobreak) continue;
+        _foundfuncsorder.push_back(kv.first);
+        found.insert(kv.first->decl);
+      }
+    }
+  }
+
+  // "Applies" `def` using arguments in `fapp`
+  Expr applyDefinition(Expr fapp, const SynthFunc& func, Expr def)
+  {
+    // TODO: Assumes single application
+    vector<Expr> argfrom, argto;
+    assert(isOpX<FAPP>(fapp));
+
+    for (int i = 0; i < func.vars.size(); ++i)
+      argfrom.push_back(bind::fapp(func.vars[i]));
+    for (int i = 1; i < fapp->arity(); ++i)
+      argto.push_back(fapp->arg(i));
+    Expr out = replaceAll(def, argfrom, argto);
+    out = replaceFapps(out);
+    return out;
+  }
+
+  // Replace applications of synth-fun's with their definitions
+  Expr replaceFapps(Expr e)
+  {
+    RW<function<Expr(Expr)>> recrw(new function<Expr(Expr)>(
+      [&] (Expr e) -> Expr
+      {
+        if (isOpX<FAPP>(e))
+        {
+          for (const auto &kv : foundfuncs)
+            if (kv.first->decl == e->left())
+              return applyDefinition(e, *kv.first, kv.second);
+        }
+        return e;
+      }));
+    return dagVisit(recrw, e);
+  }
+
+  // Check the found functions against the constraints
+  bool sanityCheck()
+  {
+    const bool doExtraCheck = false;
+    Expr allcons = conjoin(prob.constraints, efac);
+    allcons = replaceFapps(allcons);
+
+    ZSolver<EZ3> smt(z3);
+    smt.assertExpr(mk<NEG>(allcons));
+    tribool ret = smt.solve();
+    if (ret && debug)
+    {
+      outs() << "Sanity check:\n";
+      smt.toSmtLib(outs());
+      ExprSet allVars;
+      filter(allcons, bind::IsConst(), inserter(allVars, allVars.begin()));
+      ZSolver<EZ3>::Model* m = smt.getModelPtr();
+      if (m)
+      {
+        outs() << "Model for sanity check:\n";
+        for (const Expr& v : allVars)
+          outs() << v << " = " << m->eval(v) << endl;
+      }
+    }
+
+    if (doExtraCheck)
+    {
+      int noz3 = system("z3 -version >&-");
+      if (noz3)
+      {
+        errs() << "Warning: Extra check requested but Z3 not installed. Skipping.\n";
+        return bool(!ret);
+      }
+
+      char tmpfilename[7];
+      strcpy(tmpfilename, "XXXXXX");
+      int tmpfilefd = mkstemp(tmpfilename);
+      assert(tmpfilefd);
+      ostringstream os;
+      ofstream tmpfilestream(tmpfilename);
+
+      for (const SynthFunc* func : foundfuncsorder)
+        os << func->GetDefFun(foundfuncs.at(func), u, false) << "\n";
+
+      vector<Expr> fapps;
+      Expr negconsts = mk<NEG>(conjoin(prob.constraints, efac));
+      filter(negconsts, [](Expr e){return isOpX<FAPP>(e);},
+        inserter(fapps, fapps.begin()));
+
+      for (const Expr &f : fapps)
+        if (declToFunc.count(f->left()) == 0)
+          os << z3.toSmtLibDecls(f) << "\n";
+
+      os << "(assert "; u.print(negconsts, os); os << ")\n(check-sat)\n";
+
+      os.flush();
+      tmpfilestream << os.str();
+      tmpfilestream.flush();
+
+      int zret = system((string("z3 ") + tmpfilename + " >&-").c_str());
+      if (zret && (!ret || indeterminate(ret)))
+      {
+        outs() << os.str();
+        system((string("z3 -model ") + tmpfilename).c_str());
+        ret = true;
+      }
+      remove(tmpfilename);
+    }
+
+    return bool(!ret);
+  }
+
   tribool solveSingleApps()
   {
     Expr allcons = conjoin(prob.constraints, efac);
@@ -96,7 +240,11 @@ class SyGuSSolver
 
   public:
   SyGuSSolver(SynthProblem _prob, ExprFactory &_efac, EZ3 &_z3, int _debug) :
-    prob(_prob), efac(_efac), z3(_z3), debug(_debug), u(efac) {}
+    prob(_prob), efac(_efac), z3(_z3), debug(_debug), u(efac)
+  {
+    for (const auto &func : prob.synthfuncs)
+      declToFunc.emplace(func.decl, &func);
+  }
 
   // Returns success: true == solved, false == infeasible, indeterminate == fail
   tribool Solve()
@@ -105,11 +253,41 @@ class SyGuSSolver
 
     if (prob.singleapps.size() != prob.synthfuncs.size())
     {
-      _errmsg = "Solver current doesn't support multi-application functions";
+      _errmsg = "Solver current doesn't support multi-application functions (" + to_string(prob.synthfuncs.size() - prob.singleapps.size()) + " found)";
       return indeterminate;
     }
 
-    return solveSingleApps();
+    tribool ret;
+
+    ret = solveSingleApps();
+    if (!ret || indeterminate(ret))
+      return ret;
+
+    if (foundfuncs.size() != prob.singleapps.size())
+    {
+      _errmsg = "[Program Error] AE-VAL invoked on " + to_string(prob.singleapps.size()) +
+        " single-app functions but only synthesized " + to_string(foundfuncs.size()) +
+        " of them";
+      return indeterminate;
+    }
+
+    if (foundfuncs.size() != prob.synthfuncs.size())
+    {
+      _errmsg = "[Program Error] Solver invoked on " +
+        to_string(prob.synthfuncs.size()) + " functions but only synthesized " +
+        to_string(foundfuncs.size()) + " of them";
+      return indeterminate;
+    }
+
+    findOrdering();
+
+    if (!sanityCheck())
+    {
+      _errmsg = "[Program Error] Found solutions failed sanity check";
+      return indeterminate;
+    }
+
+    return true;
   }
 };
 

--- a/include/sygus/SyGuSSolver.hpp
+++ b/include/sygus/SyGuSSolver.hpp
@@ -1,0 +1,105 @@
+#ifndef __SYGUSSOLVER_HPP__
+#define __SYGUSSOLVER_HPP__
+
+#include "ae/AeValSolver.hpp"
+#include <boost/logic/tribool.hpp>
+
+namespace ufo
+{
+using namespace std;
+using namespace boost;
+
+class SyGuSSolver
+{
+  private:
+  SynthProblem prob;
+  ExprFactory &efac;
+  EZ3 &z3;
+  SMTUtils u;
+  int debug;
+
+  string _errmsg; // Non-empty if Solve() returned false
+  unordered_map<const SynthFunc*,Expr> _foundfuncs; // K: func, V: Def
+
+  public:
+  const string& errmsg = _errmsg;
+  const unordered_map<const SynthFunc*,Expr>& foundfuncs = _foundfuncs;
+
+  private:
+  tribool solveSingleApps()
+  {
+    assert(prob.synthfuncs.size() == 1);
+
+    Expr funcdecl = prob.synthfuncs[0].decl;
+
+    Expr allcons = conjoin(prob.constraints, efac);
+    Expr funcsort = funcdecl->last();
+    Expr funcout = mkConst(mkTerm<string>(getTerm<string>(funcdecl->first()) + "_out", efac), funcsort);
+    Expr singlefapp = prob.singleapps.at(funcdecl);
+    allcons = replaceAll(allcons, singlefapp, funcout);
+    vector<Expr> faArgs;
+    for (const Expr &var : prob.synthfuncs[0].vars)
+      faArgs.push_back(var);
+    vector<Expr> exArgs({ funcout->first(), allcons });
+    faArgs.push_back(mknary<EXISTS>(exArgs));
+    Expr aeProb = mknary<FORALL>(faArgs);
+    aeProb = regularizeQF(aeProb);
+    aeProb = convertIntsToReals<DIV>(aeProb);
+    if (debug > 1)
+      { outs() << "Sending to aeval: " << z3.toSmtLib(aeProb) << endl; }
+
+    ExprSet exVars({fapp(funcout->first())});
+    AeValSolver ae(mk<TRUE>(efac), aeProb->last()->last(), exVars, debug, true);
+
+    tribool aeret = ae.solve();
+    if (indeterminate(aeret))
+    {
+      _errmsg = "AE-VAL returned unknown";
+      return indeterminate;
+    }
+    else if (aeret)
+    {
+      _errmsg = "AE-VAL determined conjecture was infeasible";
+      errs() << "Model for conjecture:\n";
+      ae.printModelNeg(errs());
+      errs() << "\n";
+      return false;
+    }
+    else
+    {
+      // AE-VAL returns (= fname def)
+      Expr func = ae.getSkolemFunction(true)->right();
+      func = simplifyBool(simplifyArithm(func));
+      _foundfuncs[&prob.synthfuncs[0]] = func;
+      return true;
+    }
+  }
+
+  public:
+  SyGuSSolver(SynthProblem _prob, ExprFactory &_efac, EZ3 &_z3, int _debug) :
+    prob(_prob), efac(_efac), z3(_z3), debug(_debug), u(efac) {}
+
+  // Returns success: true == solved, false == infeasible, indeterminate == fail
+  tribool Solve()
+  {
+    prob.Analyze();
+
+    if (prob.synthfuncs.size() != 1)
+    {
+      _errmsg = "Solver currently doesn't support synthesizing multiple functions";
+      return indeterminate;
+    }
+
+    if (prob.singleapps.size() != prob.synthfuncs.size())
+    {
+      _errmsg = "Solver current doesn't support multi-application functions";
+      return indeterminate;
+    }
+
+    return solveSingleApps();
+  }
+};
+
+}
+
+#endif

--- a/include/sygus/SyGuSSolver.hpp
+++ b/include/sygus/SyGuSSolver.hpp
@@ -50,14 +50,14 @@ class SyGuSSolver
 
     for (const auto& kv : prob.singleapps)
       for (int i = 1; i < kv.second->arity(); ++i)
-        faArgs.push_back(kv.second->arg(i));
+        faArgs.push_back(kv.second->arg(i)->left());
     exArgs.push_back(allcons);
     faArgs.push_back(mknary<EXISTS>(exArgs));
     Expr aeProb = mknary<FORALL>(faArgs);
     aeProb = regularizeQF(aeProb);
     aeProb = convertIntsToReals<DIV>(aeProb);
     if (debug > 1)
-      { outs() << "Sending to aeval: " << z3.toSmtLib(aeProb) << endl; }
+      { outs() << "Sending to aeval: "; u.print(aeProb); outs() << endl; }
 
     AeValSolver ae(mk<TRUE>(efac), aeProb->last()->last(), exVars, debug, true);
 

--- a/include/sygus/SynthProblem.hpp
+++ b/include/sygus/SynthProblem.hpp
@@ -1,0 +1,33 @@
+#ifndef __SYNTHPROBLEM_HPP__
+#define __SYNTHPROBLEM_HPP__
+
+#include <string>
+#include "ufo/Expr.hpp"
+
+namespace ufo
+{
+using namespace std;
+using namespace expr;
+
+enum class SynthFuncType { NONE, SYNTH, INV };
+
+class SynthFunc
+{
+  public:
+  SynthFuncType type;
+  Expr decl;
+
+  SynthFunc(SynthFuncType _type, Expr _decl) : type(_type), decl(_decl) {}
+};
+
+class SynthProblem
+{
+  public:
+  string logic;
+  vector<SynthFunc> synthfuncs;
+  vector<Expr> constraints;
+};
+
+}
+
+#endif

--- a/include/sygus/SynthProblem.hpp
+++ b/include/sygus/SynthProblem.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include "ufo/Expr.hpp"
+#include "ae/SMTUtils.hpp"
 
 namespace yy { class parser; }
 
@@ -24,6 +25,27 @@ class SynthFunc
     type(_type), decl(_decl), vars(_vars) {}
   SynthFunc(SynthFuncType _type, Expr _decl, vector<Expr>&& _vars) :
     type(_type), decl(_decl), vars(_vars) {}
+
+  // Convert to (define-fun ...)
+  string GetDefFun(Expr def, SMTUtils& u, bool newlines = false) const
+  {
+    ostringstream os;
+    os << "(define-fun " << decl->first() << " (";
+    for (int i = 0; i < vars.size(); ++i)
+    {
+      const Expr& var = vars[i];
+      if (i != 0) os << " ";
+      os << "(" << var->first() << " "; u.print(var->last(), os); os << ")";
+    }
+    os << ") "; u.print(decl->last(), os);
+    if (newlines) os << "\n";
+    os << "  ";
+    u.print(def, os);
+    if (newlines) os << "\n";
+    os << ")";
+    os.flush();
+    return os.str();
+  }
 };
 
 class SynthProblem

--- a/tools/aeval/Ae.cpp
+++ b/tools/aeval/Ae.cpp
@@ -1,5 +1,6 @@
 #include "ae/AeValSolver.hpp"
 #include "ufo/Smt/EZ3.hh"
+#include "ae/CLIParsing.hpp"
 
 using namespace ufo;
 
@@ -20,45 +21,6 @@ using namespace ufo;
  *   ../test/ae/example1_t_part.smt2
  *
  */
-
-bool getBoolValue(const char * opt, bool defValue, int argc, char ** argv)
-{
-  for (int i = 1; i < argc; i++)
-  {
-    if (strcmp(argv[i], opt) == 0) return true;
-  }
-  return defValue;
-}
-
-int getIntValue(const char * opt, int defValue, int argc, char ** argv)
-{
-  for (int i = 1; i < argc-1; i++)
-  {
-    if (strcmp(argv[i], opt) == 0)
-    {
-      char* p;
-      int num = strtol(argv[i+1], &p, 10);
-      if (*p) return 1;      // if used w/o arg, return boolean
-      else return num;
-    }
-  }
-  return defValue;
-}
-
-char * getSmtFileName(int num, int argc, char ** argv)
-{
-  int num1 = 1;
-  for (int i = 1; i < argc; i++)
-  {
-    int len = strlen(argv[i]);
-    if (len >= 5 && strcmp(argv[i] + len - 5, ".smt2") == 0)
-    {
-      if (num1 == num) return argv[i];
-      else num1++;
-    }
-  }
-  return NULL;
-}
 
 void printUsage()
 {

--- a/tools/aeval/CMakeLists.txt
+++ b/tools/aeval/CMakeLists.txt
@@ -1,3 +1,6 @@
 add_executable (aeval Ae.cpp)
 target_link_libraries (aeval ${Z3_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${GMPXX_LIB} ${GMP_LIB})
+#if (BISON_FOUND)
+  add_dependencies(aeval SyGuSParserBison)
+#endif()
 install(TARGETS aeval RUNTIME DESTINATION bin)

--- a/tools/sygus/CMakeLists.txt
+++ b/tools/sygus/CMakeLists.txt
@@ -4,3 +4,10 @@ target_link_libraries(sygustestparser ${Z3_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${GM
 add_dependencies(sygustestparser SyGuSParserBison)
 #endif()
 install(TARGETS sygustestparser RUNTIME DESTINATION bin)
+
+add_executable(sygussolver sygussolver.cpp)
+target_link_libraries(sygussolver ${Z3_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${GMPXX_LIB} ${GMP_LIB})
+#if (BISON_FOUND)
+add_dependencies(sygussolver SyGuSParserBison)
+#endif()
+install(TARGETS sygussolver RUNTIME DESTINATION bin)

--- a/tools/sygus/CMakeLists.txt
+++ b/tools/sygus/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(sygustestparser testparser.cpp)
+target_link_libraries(sygustestparser ${Z3_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${GMPXX_LIB} ${GMP_LIB})
+#if (BISON_FOUND)
+add_dependencies(sygustestparser SyGuSParserBison)
+#endif()
+install(TARGETS sygustestparser RUNTIME DESTINATION bin)

--- a/tools/sygus/checkresult.sh
+++ b/tools/sygus/checkresult.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+# Runs the SyGuS solver, checking the result returned with Z3 (if found)
+
+if [ $# -ne 1 -o "$1" = "--help" ]
+then
+  echo "Usage: $(basename "$0") program.sl"
+  echo
+  echo "Runs SyGuS solver on given program, and checks the result returned"
+  echo "with Z3 to ensure it's correct."
+  exit 1
+fi
+
+program=""
+getprog() {
+  shift $(( $# - 1 ))
+  program="$1"
+}
+getprog "$@"
+program="$(realpath "$program")"
+
+cd "$(realpath "$(dirname "$0")")"
+
+sout="$(mktemp)"
+serr="$(mktemp)"
+trap "rm -f $sout $serr;" EXIT
+trap "rm -f $sout $serr; kill -KILL -0;" QUIT TERM INT
+
+../../build/tools/sygus/sygussolver "$program" > "$sout" 2> "$serr"
+ret=$?
+pout="$(cat "$sout")"
+perr="$(cat "$serr")"
+rm -f "$sout" "$serr"
+
+if [ "$pout" = "fail" -o "$pout" = "infeasible" -o $ret -ne 0 ]
+then
+  echo "$perr"
+  echo "$pout"
+  echo "[checkresult.sh] No solution found."
+  exit $ret
+fi
+
+if cat "$program" | grep -E -q 'chc-constraint|inv-constraint'
+then
+  echo "[checkresult.sh] Program includes chc- or inv-constraint, currently unsupported"
+  exit 9
+fi
+
+# Won't work because we need ~a V ~b, not ~a /\ ~b
+smtprog="$(cat "$program" | grep -E 'constraint|declare-.*|define-.*' |
+  sed -r '/^\(constraint/{s/^\(constraint(.*)\)$/\1/;H;s/.*//;};${p;s/.*//;x;s/\n/ /g;s/^/\(assert \(not \(and /;s/$/\)\)\)/;s/  */ /g;}')"
+
+z3in="$(printf "%s\n%s\n(check-sat)\n" "$pout" "$smtprog")"
+z3resp="$(echo "$z3in" | z3 -in)"
+if echo "$z3resp" | grep -q 'error'
+then
+    echo "Z3 error"
+    echo "SMT file:"
+    echo "$z3in"
+    echo
+    echo "Z3 output:"
+    echo "$z3resp"
+    exit 11
+elif ! echo "$z3resp" | grep -q -e '^sat$'
+then
+    echo "$pout"
+    exit 0
+else
+    echo "Faulty synthesis found:"
+    echo "$pout"
+    echo "SMT file:"
+    echo "$z3in"
+    echo
+    echo "Z3 output:"
+    echo "$z3in" | z3 -model -in
+    exit 1
+fi

--- a/tools/sygus/sygussolver.cpp
+++ b/tools/sygus/sygussolver.cpp
@@ -1,0 +1,98 @@
+
+#include <cstdio>
+#include <boost/logic/tribool.hpp>
+
+#include "ae/CLIParsing.hpp"
+#include "ae/SMTUtils.hpp"
+#include "ufo/Expr.hpp"
+#include "ufo/Smt/EZ3.hh"
+#include "sygus/SynthProblem.hpp"
+#include "sygus/SyGuSSolver.hpp"
+
+#include "sygus/SyGuSParser.bison.cpp"
+
+void printUsage()
+{
+  outs() << "Usage: sygussolver [options] <file.sl>\n";
+  outs() << "\n";
+  outs() << "Solves the given SyGuS problem specified in SyGuS-IF vers 2.0 format\n";
+  outs() << "  Options:\n";
+  outs() << "    --help            print this message\n";
+  outs() << "    --debug <lvl>     enable debug logging (higher = more)\n";
+}
+
+using namespace std;
+using namespace ufo;
+
+int main(int argc, char** argv)
+{
+  if (getBoolValue("--help", false, argc, argv) || argc == 1)
+  {
+    printUsage();
+    return 1;
+  }
+
+  int debug = getIntValue("--debug", 0, argc, argv);
+
+  char *file = getSyGuSFileName(1, argc, argv);
+
+  if (!file)
+  {
+    outs() << "No input file specified. Please specify a file in SyGuS format." << endl;
+    return 2;
+  }
+
+  yy::infile = fopen(file, "r");
+
+  if (!yy::infile)
+  {
+    errs() << "Error opening input file: " << strerror(errno) << endl;
+    return errno;
+  }
+
+  ExprFactory efac;
+  EZ3 z3(efac);
+  SMTUtils u(efac);
+  SynthProblem prob;
+  yy::parser sygusparser(prob, efac, z3);
+
+  if (debug >= 5)
+    sygusparser.set_debug_level(1);
+
+  int ret = sygusparser();
+
+  if (ret)
+    return ret;
+
+  SyGuSSolver solver(std::move(prob), efac, z3, debug);
+  tribool tret = solver.Solve();
+  if (tret)
+  {
+    for (const auto &kv : solver.foundfuncs)
+    {
+      outs() << "(define-fun " << kv.first->decl->first() << " (";
+      for (int i = 0; i < kv.first->vars.size(); ++i)
+      {
+        const Expr& var = kv.first->vars[i];
+        if (i != 0) outs() << " ";
+        outs() << "(" << var->first() << " " << z3.toSmtLib(var->last()) << ")";
+      }
+      outs() << ") " << z3.toSmtLib(kv.first->decl->last()) << "\n  ";
+      u.print(kv.second);
+      outs() << "\n)" << endl;
+    }
+    return 0;
+  }
+  else if (indeterminate(tret))
+  {
+    errs() << "Failure: " << solver.errmsg << endl;
+    outs() << "fail" << endl; // Comply with SyGuS-IF v2.0
+    return 3;
+  }
+  else
+  {
+    errs() << "Infeasible: " << solver.errmsg << endl;
+    outs() << "infeasible" << endl; // Comply with SyGuS-IF v2.0
+    return 4;
+  }
+}

--- a/tools/sygus/sygussolver.cpp
+++ b/tools/sygus/sygussolver.cpp
@@ -68,18 +68,9 @@ int main(int argc, char** argv)
   tribool tret = solver.Solve();
   if (tret)
   {
-    for (const auto &kv : solver.foundfuncs)
+    for (const auto &f : solver.foundfuncsorder)
     {
-      outs() << "(define-fun " << kv.first->decl->first() << " (";
-      for (int i = 0; i < kv.first->vars.size(); ++i)
-      {
-        const Expr& var = kv.first->vars[i];
-        if (i != 0) outs() << " ";
-        outs() << "(" << var->first() << " " << z3.toSmtLib(var->last()) << ")";
-      }
-      outs() << ") " << z3.toSmtLib(kv.first->decl->last()) << "\n  ";
-      u.print(kv.second);
-      outs() << "\n)" << endl;
+      outs() << f->GetDefFun(solver.foundfuncs.at(f), u, true) << endl;
     }
     return 0;
   }

--- a/tools/sygus/testparser.cpp
+++ b/tools/sygus/testparser.cpp
@@ -1,0 +1,33 @@
+#include <cstring>
+
+#include "ufo/Expr.hpp"
+#include "ufo/Smt/EZ3.hh"
+
+#include "sygus/SyGuSParser.bison.cpp"
+
+int main(int argc, const char** argv)
+{
+  expr::ExprFactory efac;
+  ufo::EZ3 z3(efac);
+  ufo::SynthProblem prob;
+
+  if (argc > 2 || (argc > 1 && !strcmp(argv[1], "--help")))
+  {
+    printf("Usage: %s [filename]\n", argv[0]);
+    return 1;
+  }
+
+  if (argc == 2)
+    yy::infile = fopen(argv[1], "r");
+  else
+    yy::infile = stdin;
+
+  yy::parser parse(prob, efac, z3);
+  int ret;
+
+  //parse.set_debug_level(9);
+
+  ret = parse();
+
+  return ret;
+}


### PR DESCRIPTION
Adds support for SyGuS-IF 2.0 files. The standard `aeval` tool is unchanged; use the `sygussolver` tool instead. Support is limited to the set of problems that AE-VAL can solve on its own, i.e. exclusively single-application functions (though we support synthesizing an arbitrary number of them). Parsing is simple; if the file is correctly-written, it will be able to synthesize, but not all errors will be successfully detected by the tool; use [SyGuS-Org/tools](https://github.com/SyGuS-Org/tools) to verify that the files parse correctly (and to convert old SyGuS-IF 1.0 files to the newer standard). Output conforms to the standard; on successful synthesis, the function definitions in SMT-LIBv2 format will be printed; on failure, 'fail' will be printed if the tool was unable to derive a result, 'infeasible' if the synthesis problem is invalid.

#29 and #30 are not strictly necessary for this PR, but are nice to have.