### PR TITLE
Improve Speed of Compaction

### DIFF
--- a/src/ae/AeValSolver.hpp
+++ b/src/ae/AeValSolver.hpp
@@ -5,6 +5,7 @@
 #include "ae/SMTUtils.hpp"
 #include "ufo/Smt/EZ3.hh"
 #include "ae/MBPUtils.hpp"
+#include "ae/SetHash.hpp"
 
 using namespace std;
 using namespace boost;
@@ -37,6 +38,7 @@ namespace ufo
     vector<ExprMap> someEvals;
     ExprSet sensitiveVars; // for compaction
     set<int> bestIndexes; // for compaction
+    unordered_set<set<int>> doneIndexes; // for compaction
     map<Expr, ExprVector> skolemConstraints;
     bool skol; // whether or not to produce a skolem (function)
     int debug;
@@ -960,6 +962,8 @@ namespace ufo
             {
               set<int> indexes2 = indexes;
               indexes2.erase(j);
+              if (!doneIndexes.insert(indexes2).second)
+                return;
               searchDownwards(indexes2, var, skol);
             }
           }
@@ -1069,6 +1073,7 @@ namespace ufo
       ExprSet skolUncond;
       ExprSet eligibleVars;
       skolemConstraints.clear(); // GF: just in case
+      doneIndexes.clear();
 
       // GF: to clean further
       for (auto &var: v)

--- a/src/ae/SetHash.hpp
+++ b/src/ae/SetHash.hpp
@@ -1,0 +1,24 @@
+#ifndef SETHASH__HPP__
+#define SETHASH__HPP__
+
+#include <boost/container_hash/hash.hpp>
+
+namespace std
+{
+template <typename T, typename Comp, typename Alloc>
+struct hash<set<T,Comp,Alloc>>
+{
+  size_t operator()(const set<T,Comp,Alloc>& obj) const
+  {
+    auto itr = obj.begin();
+    auto end = obj.end();
+    auto hashT = hash<T>();
+    size_t outhash = hashT(*itr);
+    ++itr;
+    for (; itr != end; ++itr)
+      boost::hash_combine(outhash, hashT(*itr));
+    return outhash;
+  }
+};
+}
+#endif

--- a/src/sygus/SyGuSParser.yy
+++ b/src/sygus/SyGuSParser.yy
@@ -146,7 +146,7 @@ ufo::SynthFunc addFunc(ufo::EZ3& z3, std::string name,
   toparse += ") " + z3.toSmtLib(sort) + ")";
   yy::funcs.insert(name);
   return ufo::SynthFunc( type,
-    expr::bind::fdecl(expr::mkTerm<std::string>(name, sort->efac()),
+    expr::op::bind::fdecl(expr::mkTerm<std::string>(name, sort->efac()),
     declArgs), vardecls);
 }
 
@@ -212,7 +212,7 @@ vardecls:
            {
               std::swap($$, $5);
               // Note: this can be used directly for quantifiers, NOT for fdecls
-              $$.insert($$.begin(), expr::bind::constDecl(
+              $$.insert($$.begin(), expr::op::bind::constDecl(
                 ufo::mkTerm<std::string>($2, efac), $3));
            }
          | {}

--- a/src/sygus/SyGuSSolver.hpp
+++ b/src/sygus/SyGuSSolver.hpp
@@ -10,6 +10,11 @@ namespace ufo
 using namespace std;
 using namespace boost;
 
+// The maximum partitioning size at which to compact the produced formula
+//  (since the compaction algorithm currently scales with the partitioning size)
+// Determined empirically
+const int MAX_ITERS_FOR_COMPACT = 12;
+
 class SyGuSSolver
 {
   private:
@@ -236,7 +241,10 @@ class SyGuSSolver
     else
     {
       // AE-VAL returns (= fname def)
-      Expr funcs_conj = ae.getSkolemFunction(true);
+      // TODO: Make option?
+      // TODO: Disable when AE-VAL's compaction is better?
+      bool compact = ae.getPartitioningSize() <= MAX_ITERS_FOR_COMPACT;
+      Expr funcs_conj = ae.getSkolemFunction(compact);
       if (isOpX<EQ>(funcs_conj))
         // Just for ease of use; WON'T MARSHAL
         funcs_conj = mk<AND>(funcs_conj);


### PR DESCRIPTION
When passing 'true' to AeValSolver::getSkolemFunction, the code's
performance would, in the worst case, scale with O(n!), where n is the
number of iterations required to solve the validity of the problem.
While this is fine for small programs, larger ones often take
>10 iterations which was resulting in an explosion of run time.

Now, we (roughly) scale with O(2^n). While this is still not ideal, this
is still a substantial improvement, and the best I can do without
understanding the algorithm better.

Also, limits the maximum partitioning size for which we compact
automatically in the SyGuS tool.

Also also, fixes a compiler error on my end.