### PR TITLE
Integrate new cycles data structure

### DIFF
--- a/include/deep/BndExpl.hpp
+++ b/include/deep/BndExpl.hpp
@@ -743,7 +743,7 @@ namespace ufo
 
           // for arrays, make sure the ranges are large enough
           for (auto & v : arrRanges[srcRel])
-          ssa.insert(ssa.begin(), replaceAll(mk<GT>(v, mkMPZ(k, m_efac)), srcVars, bindVars[0]));
+          ssa.insert(ssa.begin(), replaceAll(mk<GEQ>(v, mkMPZ(k, m_efac)), srcVars, bindVars[0]));
 
           bool toContinue = false;
           bool noopt = false;

--- a/include/deep/BndExpl.hpp
+++ b/include/deep/BndExpl.hpp
@@ -31,6 +31,8 @@ namespace ufo
 
     public:
 
+    vector<ExprVector> bindVars;
+
     BndExpl (CHCs& r, bool d) :
       m_efac(r.m_efac), ruleManager(r), u(m_efac), debug(d) {}
 
@@ -108,9 +110,9 @@ namespace ufo
       }
     }
 
-    Expr compactPrefix (int num, int unr = 0)
+    Expr compactPrefix (Expr rel, int num, int unr = 0)
     {
-      vector<int> pr = ruleManager.prefixes[num];
+      vector<int> pr = ruleManager.prefixes[rel][num];
       if (pr.size() == 0) return mk<TRUE>(m_efac);
 
       for (int j = pr.size() - 1; j >= 0; j--)
@@ -120,7 +122,7 @@ namespace ufo
           pr.insert(pr.begin() + j, tmp.begin(), tmp.end());
       }
 
-      pr.push_back(ruleManager.cycles[num][0]);   // we are interested in prefixes, s.t.
+      pr.push_back(ruleManager.cycles[rel][num][0]);   // we are interested in prefixes, s.t.
                                                   // the cycle is reachable
       ExprVector ssa;
       getSSA(pr, ssa);
@@ -131,7 +133,7 @@ namespace ufo
           do {ssa.erase(ssa.begin());}
           while (!(bool)u.isSat(ssa));
         }
-        else return compactPrefix(num, unr+1);
+        else return compactPrefix(rel, num, unr+1);
       }
 
       if (ssa.empty()) return mk<TRUE>(m_efac);
@@ -141,10 +143,8 @@ namespace ufo
       Expr pref = conjoin(ssa, m_efac);
       pref = rewriteSelectStore(pref);
       pref = keepQuantifiersRepl(pref, bindVars.back());
-      return replaceAll(pref, bindVars.back(), ruleManager.chcs[ruleManager.cycles[num][0]].srcVars);
+      return replaceAll(pref, bindVars.back(), ruleManager.chcs[ruleManager.cycles[rel][num][0]].srcVars);
     }
-
-    vector<ExprVector> bindVars;
 
     Expr toExpr(vector<int>& trace)
     {
@@ -425,8 +425,9 @@ namespace ufo
 
       Expr extr = disjoin(constr, m_efac);
       if (debug) outs () << "Adding extra constraints to every iteration: " << extr << "\n";
-      for (auto & bv : bindVars)
+      for (auto & bv : bindVars) {
         diseqs.push_back(mk<ITE>(replaceAll(extr, srcVars, bv), mkMPZ(0, m_efac), mkMPZ(1, m_efac)));
+      }
       if (phaseGuard != NULL)
         for (auto & bv : bindVars)
           diseqs.push_back(mk<ITE>(replaceAll(phaseGuard, srcVars, bv), mkMPZ(0, m_efac), mkMPZ(1, m_efac)));
@@ -471,159 +472,162 @@ namespace ufo
       str = str.substr(0, str.find('.'));
       cpp_int max_double = lexical_cast<cpp_int>(str);
 
-      for (int cyc = 0; cyc < ruleManager.cycles.size(); cyc++)
-      {
-        vector<int> mainInds;
-        auto & loop = ruleManager.cycles[cyc];
-        ExprVector& srcVars = ruleManager.chcs[loop[0]].srcVars;
-        if (srcRel != ruleManager.chcs[loop[0]].srcRelation) continue;
-        if (models.size() > 0) continue;
-
-        ExprVector vars, varsMask;
-        for (int i = 0; i < srcVars.size(); i++)
+      for(auto& c: ruleManager.cycles) {
+        Expr invRel = c.first;
+        for (int cyc = 0; cyc < ruleManager.cycles[invRel].size(); cyc++)
         {
-          Expr t = typeOf(srcVars[i]);
-          if (isOpX<INT_TY>(t))
+          vector<int> mainInds;
+          auto & loop = ruleManager.cycles[invRel][cyc];
+          ExprVector& srcVars = ruleManager.chcs[loop[0]].srcVars;
+          if (srcRel != ruleManager.chcs[loop[0]].srcRelation) continue;
+          if (models.size() > 0) continue;
+
+          ExprVector vars, varsMask;
+          for (int i = 0; i < srcVars.size(); i++)
           {
-            mainInds.push_back(i);
-            vars.push_back(srcVars[i]);
-            varsMask.push_back(srcVars[i]);
-          }
-          else if (isOpX<ARRAY_TY>(t) && ruleManager.hasArrays[srcRel])
-          {
-            Expr v = findSelect(loop[0], i);
-            if (v != NULL)
+            Expr t = typeOf(srcVars[i]);
+            if (isOpX<INT_TY>(t))
             {
-              vars.push_back(v);
-              mainInds.push_back(-i - 1);  // to be on the negative side
+              mainInds.push_back(i);
+              vars.push_back(srcVars[i]);
               varsMask.push_back(srcVars[i]);
             }
+            else if (isOpX<ARRAY_TY>(t) && ruleManager.hasArrays[srcRel])
+            {
+              Expr v = findSelect(loop[0], i);
+              if (v != NULL)
+              {
+                vars.push_back(v);
+                mainInds.push_back(-i - 1);  // to be on the negative side
+                varsMask.push_back(srcVars[i]);
+              }
+            }
           }
-        }
 
-        if (vars.size() < 2 && cyc == ruleManager.cycles.size() - 1)
+          if (vars.size() < 2 && cyc == ruleManager.cycles[invRel].size() - 1)
           continue; // does not make much sense to run with only one var when it is the last cycle
-        invVars = vars;
+          invVars = vars;
 
-        auto & prefix = ruleManager.prefixes[cyc];
-        vector<int> trace;
-        int l = 0;                              // starting index (before the loop)
-        if (ruleManager.hasArrays[srcRel]) l++; // first iter is usually useless
+          auto & prefix = ruleManager.prefixes[invRel][cyc];
+          vector<int> trace;
+          int l = 0;                              // starting index (before the loop)
+          if (ruleManager.hasArrays[srcRel]) l++; // first iter is usually useless
 
-        for (int j = 0; j < k; j++)
+          for (int j = 0; j < k; j++)
           for (int m = 0; m < loop.size(); m++)
-            trace.push_back(loop[m]);
+          trace.push_back(loop[m]);
 
-        ExprVector ssa;
-        getSSA(trace, ssa);
-        if (fwd)
-        {
-          ssa.push_back(invs);
-          ssa.push_back(replaceAll(phaseGuard, srcVars, bindVars[loop.size() - 1]));
-        }
-        else
-        {
-          ssa.push_back(phaseGuard);
-          ssa.push_back(replaceAll(invs, srcVars, bindVars[loop.size() - 1]));
-        }
-        bindVars.pop_back();
-
-        // compute vars for opt constraint
-        vector<ExprVector> versVars;
-        ExprSet allVars;
-        ExprVector diseqs;
-        fillVars(srcRel, srcVars, vars, l, loop.size(), mainInds, versVars, allVars);
-        getOptimConstr(versVars, vars.size(), srcVars, constr, phaseGuard, diseqs);
-
-        Expr cntvar = bind::intConst(mkTerm<string> ("_FH_cnt", m_efac));
-        allVars.insert(cntvar);
-        allVars.insert(bindVars.back().begin(), bindVars.back().end());
-        ssa.push_back(mk<EQ>(cntvar, mkplus(diseqs, m_efac)));
-
-        auto res = u.isSat(ssa);
-        if (indeterminate(res) || !res)
-        {
-          if (debug) outs () << "Unable to solve the BMC formula for " <<  srcRel << " and phase guard " << phaseGuard <<"\n";
-          continue;
-        }
-        ExprMap allModels;
-        u.getOptModel<GT>(allVars, allModels, cntvar);
-
-        ExprSet phaseGuardVars;
-        set<int> phaseGuardVarsIndex; // Get phaseGuard vars here
-        filter(phaseGuard, bind::IsConst(), inserter(phaseGuardVars, phaseGuardVars.begin()));
-        for (auto & a : phaseGuardVars)
-        {
-          int i = getVarIndex(a, varsMask);
-          assert(i >= 0);
-          phaseGuardVarsIndex.insert(i);
-        }
-
-        if (debug) outs () << "\nUnroll and execute the cycle for " <<  srcRel << " and phase guard " << phaseGuard <<"\n";
-
-        for (int j = 0; j < versVars.size(); j++)
-        {
-          vector<double> model;
-          if (debug) outs () << "  model for " << j << ": [";
-          bool toSkip = false;
-          SMTUtils u2(m_efac);
-          ExprSet equalities;
-
-          for (auto i: phaseGuardVarsIndex)
+          ExprVector ssa;
+          getSSA(trace, ssa);
+          if (fwd)
           {
-            Expr srcVar = varsMask[i];
-            Expr bvar = versVars[j][i];
-            if (isOpX<SELECT>(bvar)) bvar = bvar->left();
-            Expr m = allModels[bvar];
-            if (m == NULL) { toSkip = true; break; }
-            equalities.insert(mk<EQ>(srcVar, m));
+            ssa.push_back(invs);
+            ssa.push_back(replaceAll(phaseGuard, srcVars, bindVars[loop.size() - 1]));
           }
-          if (toSkip) continue;
-          equalities.insert(phaseGuard);
+          else
+          {
+            ssa.push_back(phaseGuard);
+            ssa.push_back(replaceAll(invs, srcVars, bindVars[loop.size() - 1]));
+          }
+          bindVars.pop_back();
 
-          if (u2.isSat(equalities)) //exclude models that don't satisfy phaseGuard
+          // compute vars for opt constraint
+          vector<ExprVector> versVars;
+          ExprSet allVars;
+          ExprVector diseqs;
+          fillVars(srcRel, srcVars, vars, l, loop.size(), mainInds, versVars, allVars);
+          getOptimConstr(versVars, vars.size(), srcVars, constr, phaseGuard, diseqs);
+
+          Expr cntvar = bind::intConst(mkTerm<string> ("_FH_cnt", m_efac));
+          allVars.insert(cntvar);
+          allVars.insert(bindVars.back().begin(), bindVars.back().end());
+          ssa.push_back(mk<EQ>(cntvar, mkplus(diseqs, m_efac)));
+
+          auto res = u.isSat(ssa);
+          if (indeterminate(res) || !res)
+          {
+            if (debug) outs () << "Unable to solve the BMC formula for " <<  srcRel << " and phase guard " << phaseGuard <<"\n";
+            continue;
+          }
+          ExprMap allModels;
+          u.getOptModel<GT>(allVars, allModels, cntvar);
+
+          ExprSet phaseGuardVars;
+          set<int> phaseGuardVarsIndex; // Get phaseGuard vars here
+          filter(phaseGuard, bind::IsConst(), inserter(phaseGuardVars, phaseGuardVars.begin()));
+          for (auto & a : phaseGuardVars)
+          {
+            int i = getVarIndex(a, varsMask);
+            assert(i >= 0);
+            phaseGuardVarsIndex.insert(i);
+          }
+
+          if (debug) outs () << "\nUnroll and execute the cycle for " <<  srcRel << " and phase guard " << phaseGuard <<"\n";
+
+          for (int j = 0; j < versVars.size(); j++)
           {
             vector<double> model;
+            if (debug) outs () << "  model for " << j << ": [";
+            bool toSkip = false;
+            SMTUtils u2(m_efac);
+            ExprSet equalities;
 
-            for (int i = 0; i < vars.size(); i++) {
+            for (auto i: phaseGuardVarsIndex)
+            {
+              Expr srcVar = varsMask[i];
               Expr bvar = versVars[j][i];
+              if (isOpX<SELECT>(bvar)) bvar = bvar->left();
               Expr m = allModels[bvar];
-              double value;
-              if (m != NULL && isOpX<MPZ>(m))
-              {
-                if (lexical_cast<cpp_int>(m) > max_double ||
-                    lexical_cast<cpp_int>(m) < -max_double)
+              if (m == NULL) { toSkip = true; break; }
+              equalities.insert(mk<EQ>(srcVar, m));
+            }
+            if (toSkip) continue;
+            equalities.insert(phaseGuard);
+
+            if (u2.isSat(equalities)) //exclude models that don't satisfy phaseGuard
+            {
+              vector<double> model;
+
+              for (int i = 0; i < vars.size(); i++) {
+                Expr bvar = versVars[j][i];
+                Expr m = allModels[bvar];
+                double value;
+                if (m != NULL && isOpX<MPZ>(m))
+                {
+                  if (lexical_cast<cpp_int>(m) > max_double ||
+                  lexical_cast<cpp_int>(m) < -max_double)
+                  {
+                    toSkip = true;
+                    break;
+                  }
+                  value = lexical_cast<double>(m);
+                }
+                else
                 {
                   toSkip = true;
                   break;
                 }
-                value = lexical_cast<double>(m);
-              }
-              else
-              {
-                toSkip = true;
-                break;
-              }
-              model.push_back(value);
-              if (debug) outs () << *bvar << " = " << *m << ", ";
-              if (j == 0)
-              {
-                Expr arr = bvar;
-                while (isOpX<SELECT>(arr) || isOpX<STORE>(arr))
+                model.push_back(value);
+                if (debug) outs () << *bvar << " = " << *m << ", ";
+                if (j == 0)
+                {
+                  Expr arr = bvar;
+                  while (isOpX<SELECT>(arr) || isOpX<STORE>(arr))
                   arr = arr->left();
-                if (arr != bvar)
+                  if (arr != bvar)
                   concrInvs[srcRel].insert(mk<EQ>(vars[i]->left(), allModels[arr]));
-                else
+                  else
                   concrInvs[srcRel].insert(mk<EQ>(vars[i], m));
+                }
               }
+              if (!toSkip) models.push_back(model);
             }
-            if (!toSkip) models.push_back(model);
+            else
+            {
+              if (debug) outs () << "   <  skipping  >      ";
+            }
+            if (debug) outs () << "\b\b]\n";
           }
-          else
-          {
-            if (debug) outs () << "   <  skipping  >      ";
-          }
-          if (debug) outs () << "\b\b]\n";
         }
       }
 
@@ -647,203 +651,209 @@ namespace ufo
       map<int, Expr> exprModels;
       bool res = false;
 
-      for (int cyc = 0; cyc < ruleManager.cycles.size(); cyc++)
+      for(auto& c : ruleManager.cycles)
       {
-        vector<int> mainInds;
-        auto & loop = ruleManager.cycles[cyc];
-        Expr srcRel = ruleManager.chcs[loop[0]].srcRelation;
-        ExprVector& srcVars = ruleManager.chcs[loop[0]].srcVars;
-        if (models[srcRel].size() > 0) continue;
-
-        ExprVector vars;
-        for (int i = 0; i < srcVars.size(); i++)
+        Expr invRel = c.first;
+        for (int cyc = 0; cyc < ruleManager.cycles[invRel].size(); cyc++)
         {
-          Expr t = typeOf(srcVars[i]);
-          if (isOpX<INT_TY>(t))
+          vector<int> mainInds;
+          auto & loop = ruleManager.cycles[invRel][cyc];
+          Expr srcRel = invRel;
+          // Expr srcRel = ruleManager.chcs[loop[0]].srcRelation;
+          ExprVector& srcVars = ruleManager.chcs[loop[0]].srcVars;
+          if (models[srcRel].size() > 0) continue;
+
+          ExprVector vars;
+          for (int i = 0; i < srcVars.size(); i++)
           {
-            mainInds.push_back(i);
-            vars.push_back(srcVars[i]);
-          }
-          else if (isOpX<ARRAY_TY>(t) && ruleManager.hasArrays[srcRel])
-          {
-            Expr v = findSelect(loop[0], i);
-            if (v != NULL)
+            Expr t = typeOf(srcVars[i]);
+            if (isOpX<INT_TY>(t))
             {
-              vars.push_back(v);
-              mainInds.push_back(-i - 1);  // to be on the negative side
+              mainInds.push_back(i);
+              vars.push_back(srcVars[i]);
+            }
+            else if (isOpX<ARRAY_TY>(t) && ruleManager.hasArrays[srcRel])
+            {
+              Expr v = findSelect(loop[0], i);
+              if (v != NULL)
+              {
+                vars.push_back(v);
+                mainInds.push_back(-i - 1);  // to be on the negative side
+              }
             }
           }
-        }
 
-        if (vars.size() < 2 && cyc == ruleManager.cycles.size() - 1)
-          continue; // does not make much sense to run with only one var when it is the last cycle
-        invVars[srcRel] = vars;
+          // Find another check to make to skip some unrollings DR
+          // if (vars.size() < 2 && cyc == ruleManager.cycles[invRel].size() - 1)
+          // continue; // does not make much sense to run with only one var when it is the last cycle
+          invVars[srcRel] = vars;
 
-        auto & prefix = ruleManager.prefixes[cyc];
-        vector<int> trace;
-        Expr lastModel = mk<TRUE>(m_efac);
+          auto & prefix = ruleManager.prefixes[invRel][cyc];
+          vector<int> trace;
+          Expr lastModel = mk<TRUE>(m_efac);
 
-        for (int p = 0; p < prefix.size(); p++)
-        {
-          if (chcsConsidered[prefix[p]] == true)
+          for (int p = 0; p < prefix.size(); p++)
           {
-            Expr lastModelTmp = exprModels[prefix[p]];
-            if (lastModelTmp != NULL) lastModel = lastModelTmp;
-            trace.clear(); // to avoid CHCs at the beginning
+            if (chcsConsidered[prefix[p]] == true)
+            {
+              Expr lastModelTmp = exprModels[prefix[p]];
+              if (lastModelTmp != NULL) lastModel = lastModelTmp;
+              trace.clear(); // to avoid CHCs at the beginning
+            }
+            trace.push_back(prefix[p]);
           }
-          trace.push_back(prefix[p]);
-        }
 
-        int l = trace.size() - 1; // starting index (before the loop)
-        if (ruleManager.hasArrays[srcRel]) l++; // first iter is usually useless
+          int l = trace.size() - 1; // starting index (before the loop)
+          if (ruleManager.hasArrays[srcRel]) l++; // first iter is usually useless
 
-        for (int j = 0; j < k; j++)
+          for (int j = 0; j < k; j++)
           for (int m = 0; m < loop.size(); m++)
-            trace.push_back(loop[m]);
+          trace.push_back(loop[m]);
 
-        int backCHC = -1;
-        for (int i = 0; i < ruleManager.chcs.size(); i++)
-        {
-          auto & r = ruleManager.chcs[i];
-          if (i != loop[0] && !r.isQuery && r.srcRelation == srcRel)
+          int backCHC = -1;
+          for (int i = 0; i < ruleManager.chcs.size(); i++)
           {
-            backCHC = i;
-            chcsConsidered[i] = true; // entry condition for the next loop
-            trace.push_back(i);
-            break;
+            auto & r = ruleManager.chcs[i];
+            if (i != loop[0] && !r.isQuery && r.srcRelation == srcRel)
+            {
+              backCHC = i;
+              chcsConsidered[i] = true; // entry condition for the next loop
+              trace.push_back(i);
+              break;
+            }
           }
-        }
 
-        ExprVector ssa;
-        getSSA(trace, ssa);
-        bindVars.pop_back();
-        int traceSz = trace.size();
-        assert(bindVars.size() == traceSz - 1);
+          ExprVector ssa;
+          getSSA(trace, ssa);
+          bindVars.pop_back();
+          int traceSz = trace.size();
+          assert(bindVars.size() == traceSz - 1);
 
-        // compute vars for opt constraint
-        vector<ExprVector> versVars;
-        ExprSet allVars;
-        ExprVector diseqs;
-        fillVars(srcRel, srcVars, vars, l, loop.size(), mainInds, versVars, allVars);
-        getOptimConstr(versVars, vars.size(), srcVars, constr[srcRel], NULL, diseqs);
+          // compute vars for opt constraint
+          vector<ExprVector> versVars;
+          ExprSet allVars;
+          ExprVector diseqs;
+          fillVars(srcRel, srcVars, vars, l, loop.size(), mainInds, versVars, allVars);
+          getOptimConstr(versVars, vars.size(), srcVars, constr[srcRel], NULL, diseqs);
 
-        Expr cntvar = bind::intConst(mkTerm<string> ("_FH_cnt", m_efac));
-        allVars.insert(cntvar);
-        allVars.insert(bindVars.back().begin(), bindVars.back().end());
-        ssa.insert(ssa.begin(), mk<EQ>(cntvar, mkplus(diseqs, m_efac)));
+          Expr cntvar = bind::intConst(mkTerm<string> ("_FH_cnt", m_efac));
+          allVars.insert(cntvar);
+          allVars.insert(bindVars.back().begin(), bindVars.back().end());
+          ssa.insert(ssa.begin(), mk<EQ>(cntvar, mkplus(diseqs, m_efac)));
 
-        // for arrays, make sure the ranges are large enough
-        for (auto & v : arrRanges[srcRel])
+          // for arrays, make sure the ranges are large enough
+          for (auto & v : arrRanges[srcRel])
           ssa.insert(ssa.begin(), replaceAll(mk<GT>(v, mkMPZ(k, m_efac)), srcVars, bindVars[0]));
 
-        bool toContinue = false;
-        bool noopt = false;
-        while (true)
-        {
-          if (bindVars.size() <= 1)
+          bool toContinue = false;
+          bool noopt = false;
+          while (true)
           {
-            if (debug) outs () << "Unable to find a suitable unrolling for " << *srcRel << "\n";
-            toContinue = true;
-            break;
-          }
-
-          if (u.isSat(lastModel, conjoin(ssa, m_efac)))
-          {
-            if (backCHC != -1 && trace.back() != backCHC &&
-                trace.size() != traceSz - 1) // finalizing the unrolling (exit CHC)
+            if (bindVars.size() <= 1)
             {
-              trace.push_back(backCHC);
-              ssa.clear();                   // encode from scratch
-              getSSA(trace, ssa);
-              bindVars.pop_back();
-              noopt = true;   // TODO: support optimization queries
+              if (debug) outs () << "Unable to find a suitable unrolling for " << *srcRel << "\n";
+              toContinue = true;
+              break;
             }
-            else break;
-          }
-          else
-          {
-            noopt = true;      // TODO: support
-            if (trace.size() == traceSz)
+
+            if (u.isSat(lastModel, conjoin(ssa, m_efac)))
             {
-              trace.pop_back();
-              ssa.pop_back();
-              bindVars.pop_back();
+              if (backCHC != -1 && trace.back() != backCHC &&
+              trace.size() != traceSz - 1) // finalizing the unrolling (exit CHC)
+              {
+                trace.push_back(backCHC);
+                ssa.clear();                   // encode from scratch
+                getSSA(trace, ssa);
+                bindVars.pop_back();
+                noopt = true;   // TODO: support optimization queries
+              }
+              else break;
             }
             else
             {
-              trace.resize(trace.size()-loop.size());
-              ssa.resize(ssa.size()-loop.size());
-              bindVars.resize(bindVars.size()-loop.size());
+              noopt = true;      // TODO: support
+              if (trace.size() == traceSz)
+              {
+                trace.pop_back();
+                ssa.pop_back();
+                bindVars.pop_back();
+              }
+              else
+              {
+                trace.resize(trace.size()-loop.size());
+                ssa.resize(ssa.size()-loop.size());
+                bindVars.resize(bindVars.size()-loop.size());
+              }
             }
           }
-        }
 
-        if (toContinue) continue;
-        res = true;
-        map<int, ExprSet> ms;
+          if (toContinue) continue;
+          res = true;
+          map<int, ExprSet> ms;
 
-        ExprMap allModels;
-        if (noopt)
+          ExprMap allModels;
+          if (noopt)
           u.getModel(allVars, allModels);
-        else
+          else
           u.getOptModel<GT>(allVars, allModels, cntvar);
 
-        if (debug) outs () << "\nUnroll and execute the cycle for " <<  srcRel << "\n";
-        for (int j = 0; j < versVars.size(); j++)
-        {
-          vector<double> model;
-          bool toSkip = false;
-          if (debug) outs () << "  model for " << j << ": [";
-
-          for (int i = 0; i < vars.size(); i++)
+          if (debug) outs () << "\nUnroll and execute the cycle for " <<  srcRel << "\n";
+          for (int j = 0; j < versVars.size(); j++)
           {
-            Expr bvar = versVars[j][i];
-            Expr m = allModels[bvar];
-            double value;
-            if (m != NULL && isOpX<MPZ>(m))
+            vector<double> model;
+            bool toSkip = false;
+            if (debug) outs () << "  model for " << j << ": [";
+
+            for (int i = 0; i < vars.size(); i++)
             {
-              if (lexical_cast<cpp_int>(m) > max_double ||
-                  lexical_cast<cpp_int>(m) < -max_double)
+              Expr bvar = versVars[j][i];
+              Expr m = allModels[bvar];
+              double value;
+              if (m != NULL && isOpX<MPZ>(m))
+              {
+                if (lexical_cast<cpp_int>(m) > max_double ||
+                lexical_cast<cpp_int>(m) < -max_double)
+                {
+                  toSkip = true;
+                  break;
+                }
+                value = lexical_cast<double>(m);
+              }
+              else
               {
                 toSkip = true;
                 break;
               }
-              value = lexical_cast<double>(m);
+              model.push_back(value);
+              if (debug) outs () << *bvar << " = " << *m << ", ";
+              if (!containsOp<ARRAY_TY>(bvar))
+              ms[i].insert(mk<EQ>(vars[i], m));
+            }
+            if (toSkip)
+            {
+              if (debug) outs () << "\b\b   <  skipping  >      ]\n";
             }
             else
             {
-              toSkip = true;
-              break;
+              models[srcRel].push_back(model);
+              if (debug) outs () << "\b\b]\n";
             }
-            model.push_back(value);
-            if (debug) outs () << *bvar << " = " << *m << ", ";
-            if (!containsOp<ARRAY_TY>(bvar))
-              ms[i].insert(mk<EQ>(vars[i], m));
           }
-          if (toSkip)
-          {
-            if (debug) outs () << "\b\b   <  skipping  >      ]\n";
-          }
-          else
-          {
-            models[srcRel].push_back(model);
-            if (debug) outs () << "\b\b]\n";
-          }
-        }
 
-        for (auto & a : ms)
+          for (auto & a : ms)
           concrInvs[srcRel].insert(simplifyArithm(disjoin(a.second, m_efac)));
 
-        // although we care only about integer variables for the matrix above,
-        // we still keep the entire model to bootstrap the model generation for the next loop
-        if (chcsConsidered[trace.back()])
-        {
-          ExprSet mdls;
-          for (auto & a : bindVars.back())
+          // although we care only about integer variables for the matrix above,
+          // we still keep the entire model to bootstrap the model generation for the next loop
+          if (chcsConsidered[trace.back()])
+          {
+            ExprSet mdls;
+            for (auto & a : bindVars.back())
             if (allModels[a] != NULL)
-              mdls.insert(mk<EQ>(a, allModels[a]));
-          exprModels[trace.back()] = replaceAll(conjoin(mdls, m_efac),
+            mdls.insert(mk<EQ>(a, allModels[a]));
+            exprModels[trace.back()] = replaceAll(conjoin(mdls, m_efac),
             bindVars.back(), ruleManager.chcs[trace.back()].srcVars);
+          }
         }
       }
 

--- a/include/deep/RndLearner.hpp
+++ b/include/deep/RndLearner.hpp
@@ -407,7 +407,7 @@ namespace ufo
 
     void initializeDecl(Expr invDecl)
     {
-      if (printLog) outs () << "\nINITIALIZE PREDICATE " << invDecl << "\n=========================\n";
+      if (printLog) outs () << "\nINITIALIZE PREDICATE " << invDecl << "\n====================\n";
 //      assert (invDecl->arity() > 2);
       assert(decls.size() == invNumber);
       assert(sfs.size() == invNumber);

--- a/include/deep/RndLearner.hpp
+++ b/include/deep/RndLearner.hpp
@@ -407,7 +407,7 @@ namespace ufo
 
     void initializeDecl(Expr invDecl)
     {
-      if (printLog) outs () << "\nINITIALIZE PREDICATE " << invDecl << "\n====================\n";
+      if (printLog) outs () << "\nINITIALIZE PREDICATE " << invDecl << "\n=========================\n";
 //      assert (invDecl->arity() > 2);
       assert(decls.size() == invNumber);
       assert(sfs.size() == invNumber);

--- a/include/deep/RndLearnerV3.hpp
+++ b/include/deep/RndLearnerV3.hpp
@@ -600,19 +600,17 @@ namespace ufo
 
       ExprSet cands;
       bool rndStarted = false;
+      int lsz = ruleManager.loopheads.size();
       for (int i = 0; i < maxAttempts; i++)
       {
         // next cand (to be sampled)
         // TODO: find a smarter way to calculate; make parametrizable
-        Expr rel1 = ruleManager.loopheads[i % ruleManager.loopheads.size()];
-        int cycleNum = i % ruleManager.cycles[rel1].size();
-        int tmp = ruleManager.cycles[rel1][cycleNum][0];
-        Expr rel = ruleManager.chcs[tmp].srcRelation;
+        Expr rel = ruleManager.loopheads[i % lsz];
         int invNum = getVarIndex(rel, decls);
         candidates.clear();
         SamplFactory& sf = sfs[invNum].back();
         Expr cand = sf.getFreshCandidate();
-        if(cand == NULL) {
+        if (cand == NULL) {
           outs() << "cand is NULL\n";
           exit(1);
         }
@@ -1462,7 +1460,7 @@ namespace ufo
 
     map<Expr, ExprSet> cands;
 
-    for(auto& cyc : ruleManager.cycles) {
+    for (auto& cyc : ruleManager.cycles) {
       Expr rel = cyc.first;
       for (int i = 0; i < cyc.second.size(); i++)
       {

--- a/include/deep/RndLearnerV4.hpp
+++ b/include/deep/RndLearnerV4.hpp
@@ -216,7 +216,7 @@ namespace ufo
         cnd = cnds[0];              // TODO: extend
       }
 
-      vector<int>& cycle = ruleManager.cycles[cycleNum];
+      vector<int>& cycle = ruleManager.cycles[rel][cycleNum];
       ExprVector& srcVars = ruleManager.chcs[cycle[0]].srcVars;
       ExprVector& dstVars = ruleManager.chcs[cycle.back()].dstVars;
 
@@ -561,7 +561,6 @@ namespace ufo
     {
       if (printLog) outs () << "\nSAMPLING\n========\n";
       if (printLog >= 3)
-
         for (auto & a : deferredCandidates)
           for (auto & b : a.second)
             outs () << "  Deferred cand for " << a.first << ": " << b << "\n";
@@ -574,8 +573,9 @@ namespace ufo
       {
         // next cand (to be sampled)
         // TODO: find a smarter way to calculate; make parametrizable
-        int cycleNum = i % ruleManager.cycles.size();
-        int tmp = ruleManager.cycles[cycleNum][0];
+        Expr rel1 = ruleManager.loopheads[i % ruleManager.loopheads.size()];
+        int cycleNum = i % ruleManager.cycles[rel1].size();
+        int tmp = ruleManager.cycles[rel1][cycleNum][0];
         Expr rel = ruleManager.chcs[tmp].srcRelation;
         int invNum = getVarIndex(rel, decls);
         candidates.clear();
@@ -858,9 +858,9 @@ namespace ufo
       return true;
     }
 
-    void initializeAux(ExprSet& cands, BndExpl& bnd, int cycleNum, Expr pref)
+    void initializeAux(ExprSet& cands, BndExpl& bnd, Expr dcl, int cycleNum, Expr pref)
     {
-      vector<int>& cycle = ruleManager.cycles[cycleNum];
+      vector<int>& cycle = ruleManager.cycles[dcl][cycleNum];
       HornRuleExt* hr = &ruleManager.chcs[cycle[0]];
       Expr rel = hr->srcRelation;
       ExprVector& srcVars = hr->srcVars;
@@ -955,7 +955,10 @@ namespace ufo
         }
       }
 
-      if (!qvits[invNum].empty()) ruleManager.hasArrays[rel] = true;
+      if (!qvits[invNum].empty()) {
+        if(printLog >= 3) outs() << "rel: " << rel << " : has arrays\n";
+        ruleManager.hasArrays[rel] = true;
+      }
     }
   };
 
@@ -994,22 +997,25 @@ namespace ufo
                     dFwd, dRec, dGenerous, debug);
 
     map<Expr, ExprSet> cands;
-    for (int i = 0; i < ruleManager.cycles.size(); i++)
-    {
-      Expr dcl = ruleManager.chcs[ruleManager.cycles[i][0]].srcRelation;
-      if (ds.initializedDecl(dcl)) continue;
-      ds.initializeDecl(dcl);
-      if (!dSee) continue;
+    for(auto& cyc : ruleManager.cycles) {
+      Expr rel = cyc.first;
+      for (int i = 0; i < cyc.second.size(); i++)
+      {
+        Expr dcl = ruleManager.chcs[cyc.second[i][0]].srcRelation;
+        if (ds.initializedDecl(dcl)) continue;
+        ds.initializeDecl(dcl);
+        if (!dSee) continue;
 
-      Expr pref = bnd.compactPrefix(i);
-      ExprSet tmp;
-      getConj(pref, tmp);
-      for (auto & t : tmp)
+        Expr pref = bnd.compactPrefix(rel, i);
+        ExprSet tmp;
+        getConj(pref, tmp);
+        for (auto & t : tmp)
         if (hasOnlyVars(t, ruleManager.invVars[dcl]))
-          cands[dcl].insert(t);
+        cands[dcl].insert(t);
 
-      if (mut > 0) ds.mutateHeuristicEq(cands[dcl], cands[dcl], dcl, true);
-      ds.initializeAux(cands[dcl], bnd, i, pref);
+        if (mut > 0) ds.mutateHeuristicEq(cands[dcl], cands[dcl], dcl, true);
+        ds.initializeAux(cands[dcl], bnd, rel, i, pref);
+      }
     }
     if (dat > 0) ds.getDataCandidates(cands);
 


### PR DESCRIPTION
Cycles are now tracked as a map with each inv relation being the key.  This commit also rectifies the behavior of the query being removed when  z3 incorrectly assigns the query as a rule instead of a query.